### PR TITLE
fix: return entry body in a utf-8 encoding

### DIFF
--- a/lib/redis-cache-store.js
+++ b/lib/redis-cache-store.js
@@ -818,7 +818,9 @@ class RedisCacheManager extends EventEmitter {
     if (!value) return null
 
     const parsedValue = JSON.parse(value)
-    return parsedValue.body.join('')
+    const base64Body = parsedValue.body.join('')
+
+    return Buffer.from(base64Body, 'base64').toString('utf8')
   }
 
   /**

--- a/test/stream-entries.test.js
+++ b/test/stream-entries.test.js
@@ -88,4 +88,7 @@ test('should stream cache entries', async (t) => {
   assert.strictEqual(typeof foundEntry.cachedAt, 'number')
   assert.strictEqual(typeof foundEntry.staleAt, 'number')
   assert.strictEqual(typeof foundEntry.deleteAt, 'number')
+
+  const response = await manager.getResponseById(foundEntry.id, 'foo:bar:1:')
+  assert.strictEqual(response, 'asd')
 })


### PR DESCRIPTION
This is not efficient and we probably should do something more accurate based on the `content-type` header, but this is a fast patch to fix a breaking change.