### PR TITLE
fix: TypeScript implementation

### DIFF
--- a/lib/internal-types.d.ts
+++ b/lib/internal-types.d.ts
@@ -16,7 +16,7 @@ export interface DeleteByUri {
   path: string
 }
 
-export type GetResult = CachedResponse & { body: null | Readable | Iterable<Buffer> | Buffer | Iterable<string> | string }
+export type GetResult = CachedResponse & { body: undefined | Readable | Iterable<Buffer> | Buffer | Iterable<string> | string }
 
 /**
  * Underlying storage provider for cached responses
@@ -39,7 +39,7 @@ export interface CacheStore {
 export interface CachedResponse {
   statusCode: number;
   statusMessage: string;
-  headers?: Record<string, string | string[]>
+  headers: Record<string, string | string[]>
   /**
    * Headers defined by the Vary header and their respective values for
    *  later comparison
@@ -58,4 +58,5 @@ export interface CachedResponse {
    *  either the same as staleAt or the `max-stale` caching directive.
    */
   deleteAt: number
+  cacheControlDirectives: Record<string, string | string[]>
 }

--- a/lib/redis-cache-store.js
+++ b/lib/redis-cache-store.js
@@ -31,6 +31,7 @@ const TrackingCache = require('./tracking-cache.js')
  *  staleAt: number;
  *  deleteAt: number;
  *  body: string[]
+ *  cacheControlDirectives: Record<string, string | string[]>;
  * }} RedisValue
  *
  * @typedef {{
@@ -276,9 +277,9 @@ class RedisCacheStore extends EventEmitter {
 
     let currentSize = 0
     /**
-     * @type {string[] | null}
+     * @type {string[] | undefined}
      */
-    let body = key.method !== 'HEAD' ? [] : null
+    let body = key.method !== 'HEAD' ? [] : undefined
     const maxSize = this.#maxEntrySize
     const writeValueToRedis = this.#writeValueToRedis.bind(this)
     const errorCallback = this.#errorCallback
@@ -294,7 +295,7 @@ class RedisCacheStore extends EventEmitter {
 
         if (body) {
           if (currentSize >= maxSize) {
-            body = null
+            body = undefined
             this.end()
             return callback()
           }


### PR DESCRIPTION
Hi, I was trying to implement undici-cache-redis in our Typescript project, but noticed these issues:

Body cannot be null, should be undefined in that case.
cacheControlDirectives must be set on getResult and headers may not be undefined.

I'm running Node v22.13.1 and using built-in Undici (but ran into the same issues using latest Undici from npm).

Thanks!