### PR TITLE
Not using the header indicated in the Vary header will never use cached response.

### DIFF
--- a/lib/redis-cache-store.js
+++ b/lib/redis-cache-store.js
@@ -496,8 +496,6 @@ class RedisCacheStore extends EventEmitter {
           continue
         }
 
-        if (!key.headers) continue
-
         try {
           currentValue.vary = JSON.parse(currentValue.vary)
         } catch (err) {
@@ -506,13 +504,11 @@ class RedisCacheStore extends EventEmitter {
           continue
         }
 
-        let matches = true
-        for (const header in currentValue.vary) {
-          if (key.headers[header] !== currentValue.vary[header]) {
-            matches = false
-            break
-          }
-        }
+        key.headers = key.headers ?? {}
+        const matches = Object.entries(currentValue.vary).every(([header, value]) =>
+          (key.headers[header] === undefined && value === null) ||
+          key.headers[header] === value
+        )
 
         if (matches) {
           metadata.push({ key: metadataKey, ...currentValue })


### PR DESCRIPTION
Bug found: when the server replies with a Vary but the client does not use this header, the cached response will not be used on subsequent requests. The header in the request is `undefined`, the header in Redis/Valkey is stored as `null`. Also, when no headers are used, it's never considered a match.

Although the [specification](https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.4) is unclear about the Vary header in combination with a not-used header, it also does not require the header to be present at that moment. Vary merely says something about caching subsequent requests. For example, with a Vary: Cookie the server says that if you send a cookie it should not re-use the one without cookie, but should have its own cache entry. 

Also, when switching from Undici-cache-redis to the builtin Undici Memory cache, it does work as in this PR.