### PR TITLE
fix: TypeScript RedisCacheManager type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -61,7 +61,7 @@ export interface CacheEntry {
   deleteAt: number;
 }
 
-declare class RedisCacheManager {
+declare class RedisCacheManager extends EventEmitter{
   constructor(opts?: RedisCacheManagerOpts);
 
   streamEntries(


### PR DESCRIPTION
Although I mentioned the `RedisCacheManager` type in https://github.com/platformatic/undici-cache-redis/pull/54, I accidentally only fixed the typing of `RedisCacheStore`. This PR fixes that, both Manager and Store are extending eventEmitter.