### PR TITLE
feat: Version 2.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,9 @@ This is `undici-cache-redis`, a Redis-backed cache store for Undici's cache inte
 
 ### Core Architecture
 
-- **RedisCacheStore** (lib/redis-cache-store.js:46): Main cache store implementation that implements Undici's cache store interface
-- **RedisCacheManager** (lib/redis-cache-store.js:665): Management interface for cache operations and monitoring
-- **TrackingCache** (lib/tracking-cache.js:5): In-memory LRU cache for client-side tracking to reduce Redis round trips
+- **RedisCache** (src/v2/cache.js): Default unified cache store and management API
+- **RedisCacheStore/RedisCacheManager** (src/v1/redis-cache-store.js): Legacy V1 store and manager implementations
+- **TrackingCache** (src/v1/tracking-cache.js, src/v2/tracking-cache.js): In-memory LRU cache for client-side tracking to reduce Redis round trips
 
 The architecture uses a dual-layer caching approach:
 1. Optional client-side tracking cache (TrackingCache) for frequently accessed items

--- a/README.md
+++ b/README.md
@@ -1,19 +1,24 @@
 # undici-cache-redis
 
-A high-performance Redis-backed cache store for [Undici's](https://github.com/nodejs/undici) cache interceptor. This library provides seamless HTTP response caching with Redis/Valkey as the storage backend, featuring client-side caching, cache invalidation by tags, and support for managed Redis environments.
+Redis/Valkey-backed cache store for Undici's cache interceptor.
 
-Built on top of [iovalkey](https://github.com/valkey-io/iovalkey) for optimal Redis/Valkey connectivity.
+The default API uses a unified `RedisCache` class for both HTTP cache storage and cache-management operations, with indexed Redis data structures that avoid `SCAN` on the request lookup path.
 
 ## Features
 
-- 🚀 **High Performance**: Redis-backed caching with client-side optimization
-- 🏷️ **Cache Tags**: Invalidate cached responses by custom tags
-- 🔄 **Automatic Invalidation**: Smart cache invalidation on mutating operations
-- 📊 **Cache Management**: Built-in cache manager for monitoring and administration
-- 🌐 **Vary Header Support**: Proper handling of content negotiation
-- ☁️ **Cloud Ready**: Works with managed Redis services (AWS ElastiCache, etc.)
-- 💾 **Binary Support**: Handles both text and binary response data
-- 📈 **Tracking Cache**: Client-side caching for improved performance
+- Redis/Valkey-backed HTTP response caching for Undici.
+- Proper `Vary` support with most-specific match selection.
+- Cache invalidation by origin, method, path, id, and tags.
+- Unified store and manager API.
+- Optional client-side tracking cache.
+- Prefix-based namespacing for multi-tenant deployments.
+- Indexed data model using sorted sets and `xxhash-wasm`.
+
+## Requirements
+
+- Node.js >= 20
+- Redis >= 7.0 or Valkey >= 8.0
+- Undici >= 7.0
 
 ## Installation
 
@@ -23,26 +28,22 @@ npm install undici-cache-redis
 
 ## Quick Start
 
-### Basic Usage
-
-```javascript
+```js
 import { Agent, interceptors } from 'undici'
-import { RedisCacheStore } from 'undici-cache-redis'
+import { createStore } from 'undici-cache-redis'
 
-// Create a Redis cache store
-const store = new RedisCacheStore({
+const store = createStore({
+  prefix: 'my-app:cache',
+  // Optional Redis Cluster hash tag. If omitted, the namespace hash tag is used.
+  clusterId: 'tenant-a',
   clientOpts: {
     host: 'localhost',
-    port: 6379,
-    keyPrefix: 'my-app:cache:'
+    port: 6379
   }
 })
 
-// Create Undici agent with caching
-const agent = new Agent()
-  .compose(interceptors.cache({ store }))
+const agent = new Agent().compose(interceptors.cache({ store }))
 
-// Make requests - responses will be automatically cached
 const response = await agent.request({
   origin: 'https://api.example.com',
   method: 'GET',
@@ -52,542 +53,194 @@ const response = await agent.request({
 console.log(await response.body.text())
 ```
 
-### Cache Invalidation by Tags
+The default export is also the `RedisCache` class:
 
-```javascript
-import { Agent, interceptors } from 'undici'
-import { RedisCacheStore } from 'undici-cache-redis'
+```js
+import RedisCache from 'undici-cache-redis'
 
-const store = new RedisCacheStore({
-  cacheTagsHeader: 'cache-tags' // Header to read cache tags from
-})
-
-const agent = new Agent()
-  .compose(interceptors.cache({ store }))
-
-// Server responds with: Cache-Tags: user:123,profile
-const response = await agent.request({
-  origin: 'https://api.example.com',
-  method: 'GET',
-  path: '/users/123'
-})
-
-// Later, invalidate all cached responses tagged with 'user:123'
-await store.deleteTags(['user:123'])
+const cache = new RedisCache({ prefix: 'my-app:cache' })
 ```
 
-### Advanced Cache Management with RedisCacheManager
+## API
 
-```javascript
-import { RedisCacheStore, RedisCacheManager } from 'undici-cache-redis'
+`createStore()` and `createManager()` both return a `RedisCache` instance.
 
-// Create both store and manager
-const store = new RedisCacheStore({
+```js
+import { RedisCache, createManager, createStore } from 'undici-cache-redis'
+
+const store = createStore({ prefix: 'my-app:cache' })
+const manager = createManager({ prefix: 'my-app:cache' })
+const cache = new RedisCache({ prefix: 'my-app:cache' })
+```
+
+### Store Operations
+
+- `get(key, prefixes?, includeBody?)`
+- `getKeys(keys, prefixes?)`
+- `createWriteStream(key, value)`
+- `delete(key, prefixes?)`
+- `deleteKeys(keys, prefixes?)`
+- `deleteTag(tags, prefixes?)`
+- `deleteTags(tags, prefixes?)`
+- `deleteIds(ids, prefixes?)`
+- `close()`
+
+### Manager Operations
+
+- `entries(filter?, prefixes?)`
+- `deleteEntries(filter?, prefixes?)`
+- `streamEntries(callback, prefixes?)`
+- `getTag(tag, prefixes?)`
+- `getTags(tags, prefixes?)`
+- `getResponseById(id, prefixes?)`
+- `getDependentEntries(id, prefixes?)`
+- `subscribe(prefixes?)`
+
+Supported `entries()` / `deleteEntries()` filters:
+
+```js
+await cache.entries()
+await cache.entries({ id })
+await cache.entries({ origin })
+await cache.entries({ origin, method })
+await cache.entries({ origin, path })
+await cache.entries({ origin, method, path })
+```
+
+`delete(key)` preserves V1 semantics: it deletes all entries for `origin + path`, across all methods.
+
+`deleteKeys(keys)` deletes exact `origin + method + path` entries, or by `id` if present.
+
+## Cache Tags
+
+Configure the response header used for tags:
+
+```js
+const cache = createStore({
+  prefix: 'my-app:cache',
   cacheTagsHeader: 'cache-tags'
 })
-
-const manager = new RedisCacheManager({
-  clientOpts: { host: 'localhost', port: 6379 }
-})
-
-// Subscribe to cache events
-await manager.subscribe()
-
-manager.on('add-entry', (entry) => {
-  console.log('Cache entry added:', entry.path, entry.cacheTags)
-})
-
-manager.on('delete-entry', ({ id, keyPrefix }) => {
-  console.log('Cache entry deleted:', id)
-})
-
-// Analyze cache contents
-await manager.streamEntries((entry) => {
-  console.log(`Entry: ${entry.path}, Tags: [${entry.cacheTags.join(', ')}]`)
-}, '')
-
-// Invalidate by tags using the store
-await store.deleteTags(['user:123', 'products'])
-
-// Clean up specific entries by ID
-const entriesToDelete = []
-await manager.streamEntries((entry) => {
-  if (entry.path.startsWith('/api/products/')) {
-    entriesToDelete.push(entry.id)
-  }
-}, '')
-
-if (entriesToDelete.length > 0) {
-  await manager.deleteIds(entriesToDelete, '')
-}
-
-// Get response body for debugging
-const responseBody = await manager.getResponseById('some-entry-id', '')
 ```
 
-### Cache Management
+If the origin responds with:
 
-```javascript
-import { RedisCacheManager } from 'undici-cache-redis'
-
-const manager = new RedisCacheManager({
-  clientOpts: {
-    host: 'localhost',
-    port: 6379
-  }
-})
-
-// Subscribe to cache events
-await manager.subscribe()
-
-manager.on('add-entry', (entry) => {
-  console.log('Cache entry added:', entry.id)
-})
-
-manager.on('delete-entry', ({ id, keyPrefix }) => {
-  console.log('Cache entry deleted:', id)
-})
-
-// Stream all cache entries
-await manager.streamEntries((entry) => {
-  console.log('Entry:', entry.origin, entry.path, entry.statusCode)
-}, 'my-app:cache:')
-
-// Get response body by ID
-const responseBody = await manager.getResponseById('entry-id', 'my-app:cache:')
+```text
+Cache-Tags: user:123,profile
 ```
 
-## Configuration Options
+you can invalidate matching entries with:
 
-### RedisCacheStore Options
-
-```typescript
-interface RedisCacheStoreOpts {
-  // Redis client options (passed to iovalkey)
-  clientOpts?: {
-    host?: string
-    port?: number
-    keyPrefix?: string
-    // ... other iovalkey options
-  }
-  
-  // Maximum size in bytes for a single cached response
-  maxEntrySize?: number
-  
-  // Maximum total cache size (for client-side cache)
-  maxSize?: number
-  
-  // Maximum number of entries (for client-side cache)
-  maxCount?: number
-  
-  // Enable/disable client-side tracking cache (default: true)
-  tracking?: boolean
-  
-  // Header name to read cache tags from responses
-  cacheTagsHeader?: string
-  
-  // Error callback function
-  errorCallback?: (err: Error) => void
-}
+```js
+await cache.deleteTags(['user:123'])
+await cache.deleteTags([['user:123', 'profile']])
 ```
 
-### RedisCacheManager Options
+Tag index keys are hashed with `xxhash-wasm`; original tag names are kept in entry metadata.
 
-```typescript
-interface RedisCacheManagerOpts {
-  // Redis client options
-  clientOpts?: {
-    host?: string
-    port?: number
-    // ... other iovalkey options
-  }
-  
-  // Whether to configure keyspace event notifications (default: true)
-  // Set to false for managed Redis services
-  clientConfigKeyspaceEventNotify?: boolean
-}
+## Prefixes
+
+All keys are namespaced by `prefix` and the internal data-version segment.
+
+Most operations can target one or more prefixes:
+
+```js
+await cache.entries({}, ['tenant-a', 'tenant-b'])
+await cache.deleteTags(['user:123'], ['tenant-a', 'tenant-b'])
 ```
 
-## Advanced Usage Examples
+`clientOpts.keyPrefix` is accepted as a migration convenience, but new code should prefer `prefix`.
 
-### Using with fetch()
+Keys are Redis Cluster hash-tagged by default. Without `clusterId`, the hash tag is the namespace plus the data-version segment. With `clusterId`, only the cluster id is hash-tagged and the prefix remains outside the hash tag.
 
-```javascript
-import { Agent, interceptors, setGlobalDispatcher } from 'undici'
-import { RedisCacheStore } from 'undici-cache-redis'
+`prefix` and `clusterId` cannot contain `{` or `}`. `prefix` can be empty. `clusterId`, if provided, cannot be empty.
 
-// Create a Redis cache store
-const store = new RedisCacheStore()
+## Data Model
 
-// Create agent with caching
-const agent = new Agent()
-  .compose(interceptors.cache({ store }))
+The cache uses sorted-set indexes scored by `deleteAt`, explicit payload expiration, and `xxhash-wasm` hashes for resource identities and tag index keys.
 
-// Set as global dispatcher to enable caching for fetch
-setGlobalDispatcher(agent)
+Payload keys use `SET ... EXAT`. Index keys use `ZADD` plus `EXPIREAT ... NX` and `EXPIREAT ... GT`, so cold indexes disappear automatically and hot indexes stay alive as long as they contain live entries.
 
-// Now fetch() automatically uses the cache!
-const response = await fetch('https://api.example.com/users/123')
-const data = await response.json()
+See [docs/data-model.md](./docs/data-model.md).
 
-// Cache headers are available
-if (response.headers.get('x-cache') === 'HIT') {
-  console.log('Response was served from cache!')
-}
-```
+## Events
 
-### Working with Vary Headers
+Local events:
 
-```javascript
-const store = new RedisCacheStore()
-const agent = new Agent()
-  .compose(interceptors.cache({ store }))
+- `entry:write`
+- `entry:delete`
+- `tag:delete`
+- `error`
 
-// Different responses cached based on Accept-Language header
-const responseEn = await agent.request({
-  origin: 'https://api.example.com',
-  method: 'GET',
-  path: '/content',
-  headers: { 'Accept-Language': 'en' }
-})
+Subscription events after `await cache.subscribe()`:
 
-const responseFr = await agent.request({
-  origin: 'https://api.example.com',
-  method: 'GET',
-  path: '/content',
-  headers: { 'Accept-Language': 'fr' }
-})
-```
+- `subscription:entry:add`
+- `subscription:entry:delete`
 
-### Manual Cache Operations
-
-```javascript
-const store = new RedisCacheStore()
-
-// Delete specific cache entries
-await store.deleteKeys([
-  { origin: 'https://api.example.com', method: 'GET', path: '/users/123' }
-])
-
-// Delete by cache tags
-await store.deleteTags(['user:123', 'profile'])
-
-// Close the store when done
-await store.close()
-```
-
-### Error Handling
-
-```javascript
-const store = new RedisCacheStore({
-  errorCallback: (err) => {
-    console.error('Cache error:', err.message)
-    // Send to monitoring service
-    monitoringService.error('cache_error', err)
-  }
-})
-```
+Client-side tracking and keyspace subscriptions use separate Redis clients.
 
 ## Managed Redis Services
 
-When using managed Redis services like AWS ElastiCache, some Redis commands may be restricted. Configure the cache manager accordingly:
+For managed Redis/Valkey services where `CONFIG SET` is restricted, disable automatic keyspace configuration:
 
-```javascript
-const manager = new RedisCacheManager({
-  clientConfigKeyspaceEventNotify: false, // Disable auto-configuration
+```js
+const cache = createStore({
+  clientConfigKeyspaceEventNotify: false,
   clientOpts: {
-    host: 'your-elasticache-endpoint.cache.amazonaws.com',
+    host: 'your-cluster.cache.amazonaws.com',
     port: 6379
   }
 })
 ```
 
-Ensure your managed Redis instance has the following configuration:
-- `notify-keyspace-events AKE` (if not automatically configured)
+If you use `subscribe()`, configure keyspace notifications externally:
 
-## Multi-Host Architecture
-
-```mermaid
-graph TB
-    subgraph "Users"
-        U1[User 1]
-        U2[User 2]
-        U3[User N]
-    end
-    
-    subgraph "Host 1"
-        A1[App]
-        B1[Local Cache]
-    end
-    
-    subgraph "Host 2" 
-        A2[App]
-        B2[Local Cache]
-    end
-    
-    subgraph "Host N"
-        A3[App]
-        B3[Local Cache]
-    end
-    
-    subgraph "Redis/Valkey"
-        R[Shared Cache Storage<br/>+ Invalidation Events]
-    end
-    
-    subgraph "External APIs"
-        API[HTTP APIs]
-    end
-    
-    U1 --> A1
-    U2 --> A2
-    U3 --> A3
-    
-    A1 <--> B1
-    A2 <--> B2
-    A3 <--> B3
-    
-    B1 <--> R
-    B2 <--> R
-    B3 <--> R
-    
-    A1 --> API
-    A2 --> API
-    A3 --> API
-    
-    R -.-> B1
-    R -.-> B2
-    R -.-> B3
-    
-    classDef users fill:#e8f5e8
-    classDef app fill:#e3f2fd
-    classDef cache fill:#f3e5f5
-    classDef redis fill:#ffebee
-    classDef api fill:#fff3e0
-    
-    class U1,U2,U3 users
-    class A1,A2,A3 app
-    class B1,B2,B3 cache
-    class R redis
-    class API api
+```text
+notify-keyspace-events = AKE
 ```
-
-**Flow**: Users make requests → Apps check local/Redis cache → If miss, fetch from APIs → Cache responses → Invalidation events sync all hosts.
-
-## Cache Key Structure
-
-The library uses a structured approach to Redis keys:
-
-- **Metadata keys**: `{prefix}metadata:{origin}:{path}:{method}:{id}`
-- **Value keys**: `{prefix}values:{id}`
-- **ID keys**: `{prefix}ids:{id}`
-- **Tag keys**: `{prefix}cache-tags:{tag1}:{tag2}:{id}`
-
-Where `{prefix}` is your configured `keyPrefix` and `{id}` is a UUID for each cache entry.
-
-## Cache Invalidation Flow
-
-The following diagram illustrates how cache invalidation works across different scenarios:
-
-```mermaid
-flowchart TD
-    A[Cache Invalidation Request] --> B{Invalidation Type}
-    
-    B -->|Delete by Key| C[delete key]
-    B -->|Delete by Tags| D[deleteTags tags]
-    B -->|Automatic Cleanup| E[Redis Expiration Events]
-    
-    C --> F[Find Metadata Keys]
-    F --> G[Get Metadata from Redis]
-    G --> H[Extract Associated Keys]
-    H --> I[Delete Redis Keys]
-    I --> JJ[Redis/Valkey Key Deleted]
-    JJ --> J[Update Tracking Cache]
-    J --> K[Clean up Tags]
-    K --> L[Complete]
-    
-    D --> M[Scan for Tag Patterns]
-    M --> N[Find Matching Tag Keys]
-    N --> O[Get Metadata References]
-    O --> P[Delete Tag Keys]
-    P --> PP[Redis/Valkey Keys Deleted]
-    PP --> Q[Delete Referenced Entries]
-    Q --> R[Update Tracking Cache]
-    R --> S[Complete]
-    
-    E --> T[Redis Keyspace Event]
-    T --> U{Event Type}
-    U -->|expired| V[Entry Expiration]
-    U -->|del| W[Manual Deletion]
-    
-    V --> X[Parse Key Type]
-    X --> Y{Key Type}
-    Y -->|metadata| Z[Emit delete-entry Event]
-    Y -->|cache-tags| AA[Parse Tags from Key]
-    AA --> BB[Global Tag Cleanup]
-    BB --> CC[Delete Tag Entries]
-    CC --> DD[Complete]
-    
-    W --> X
-    Z --> DD
-    
-    %% Client-side tracking invalidation triggered by Redis updates
-    JJ --> EE[Redis Client Tracking Detects Change]
-    PP --> EE
-    EE --> FF[__redis__:invalidate Event]
-    FF --> GG[Parse Metadata Key]
-    GG --> HH[Remove from Tracking Cache]
-    HH --> II[Tracking Complete]
-    
-    %% Styling
-    classDef primary fill:#e1f5fe
-    classDef process fill:#f3e5f5
-    classDef decision fill:#fff3e0
-    classDef complete fill:#e8f5e8
-    classDef redis fill:#ffebee
-    
-    class A,C,D,E primary
-    class F,G,H,I,J,K,M,N,O,P,Q,R,T,V,W,X,AA,BB,CC,FF,GG,HH process
-    class B,U,Y decision
-    class L,S,DD,II complete
-    class JJ,PP,EE redis
-```
-
-### Invalidation Methods
-
-1. **Direct Key Deletion**: Targets specific cache entries by URL pattern
-2. **Tag-based Deletion**: Removes all entries associated with given cache tags
-3. **Automatic Expiration**: Handles Redis TTL expiration and manual deletions
-4. **Client-side Tracking**: Maintains local cache consistency via Redis invalidation notifications
-
-## Performance Considerations
-
-1. **Client-side Tracking**: Enabled by default, provides in-memory caching of metadata
-2. **Pipeline Operations**: Uses Redis pipelining for batch operations
-3. **Binary Data**: Efficiently handles binary responses with base64 encoding
-4. **Memory Management**: Configurable size limits prevent memory exhaustion
-
-## API Reference
-
-### RedisCacheStore
-
-#### Methods
-
-- `get(key: CacheKey): Promise<GetResult | undefined>` - Retrieve cached response
-- `createWriteStream(key: CacheKey, value: CachedResponse): Writable` - Create write stream for caching
-- `delete(key: CacheKey): Promise<void>` - Delete cache entries by key pattern
-- `deleteKeys(keys: CacheKey[]): Promise<void>` - Delete multiple cache entries
-- `deleteTags(tags: string[]): Promise<void>` - Delete entries by cache tags
-- `close(): Promise<void>` - Close Redis connections
-
-#### Events
-
-- `write` - Emitted when a cache entry is written
-
-### RedisCacheManager
-
-#### Methods
-
-- `streamEntries(callback, keyPrefix): Promise<void>` - Stream all cache entries
-- `subscribe(): Promise<void>` - Subscribe to cache events
-- `getResponseById(id, keyPrefix): Promise<string | null>` - Get response body by ID
-- `getDependentEntries(id, keyPrefix): Promise<CacheEntry[]>` - Get entries sharing cache tags
-- `deleteIds(ids, keyPrefix): Promise<void>` - Delete entries by IDs
-- `close(): Promise<void>` - Close connections
-
-#### Events
-
-- `add-entry` - Emitted when a cache entry is added
-- `delete-entry` - Emitted when a cache entry is deleted
-- `error` - Emitted on errors
-
-## Troubleshooting
-
-### Common Issues
-
-**Connection Errors**
-```javascript
-// Ensure Redis is running and accessible
-const store = new RedisCacheStore({
-  clientOpts: {
-    host: 'localhost',
-    port: 6379,
-    connectTimeout: 10000,
-    retryDelayOnFailover: 100
-  }
-})
-```
-
-**Memory Issues**
-```javascript
-// Limit cache size to prevent memory exhaustion
-const store = new RedisCacheStore({
-  maxEntrySize: 1024 * 1024, // 1MB per entry
-  maxSize: 100 * 1024 * 1024, // 100MB total
-  maxCount: 10000 // Max 10k entries
-})
-```
-
-**Managed Redis Issues**
-```javascript
-// For AWS ElastiCache or similar services
-const manager = new RedisCacheManager({
-  clientConfigKeyspaceEventNotify: false,
-  clientOpts: {
-    host: 'your-cluster.cache.amazonaws.com',
-    port: 6379,
-    family: 4, // Force IPv4
-    enableReadyCheck: false
-  }
-})
-```
-
-## Requirements
-
-- Node.js >= 20
-- Redis >= 6.0 or Valkey >= 7.2
-- Undici >= 7.0
-
-## License
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
 
 ## Benchmarking
 
-This project includes comprehensive benchmarks to measure performance improvements with different caching strategies.
+Run the general benchmark suite:
 
-### Quick Benchmark
 ```bash
-# Automated benchmark with all prerequisites checked
-./run-benchmarks.sh
-
-# Or run manually
 npm run bench
 ```
 
-The benchmarks test a realistic proxy server architecture:
-- **Server Foo (Proxy)**: Uses Undici with different cache configurations  
-- **Server Bar (Backend)**: API server with simulated latency
-- **Autocannon**: Load testing tool measuring performance
+Compare legacy `SCAN` lookup with indexed lookup:
 
-Expected results show **10-15x performance improvement** with caching enabled.
+```bash
+npm run bench:scan-vs-index
+```
 
-For detailed benchmarking instructions, see [benchmarks/README.md](./benchmarks/README.md).
-## Contributing
+Useful environment variables:
 
-This project is part of the Platformatic ecosystem. For contributing guidelines, please refer to the main [Platformatic repository](https://github.com/platformatic/platformatic).
+```bash
+UNRELATED_KEYS=100000 LOOKUPS=1000 VARIANTS=16 npm run bench:scan-vs-index
+```
 
-## Related Projects
+## V1 Compatibility
 
-- [Undici](https://github.com/nodejs/undici) - HTTP/1.1 client for Node.js
-- [iovalkey](https://github.com/valkey-io/iovalkey) - High-performance Valkey client
-- [Platformatic](https://github.com/platformatic/platformatic) - Enterprise-Ready Node.js
+V1 remains available for compatibility:
+
+```js
+import {
+  RedisCacheStore,
+  RedisCacheManager,
+  createStore,
+  createManager
+} from 'undici-cache-redis'
+
+const store = new RedisCacheStore(options)
+const manager = new RedisCacheManager(options)
+
+const sameStore = createStore(options, '1.0.0')
+const sameManager = createManager(options, '1.0.0')
+```
+
+See [docs/v1.md](./docs/v1.md).
+
+For migration guidance, see [docs/migration.md](./docs/migration.md).
+
+## License
+
+Licensed under the Apache License, Version 2.0. See [LICENSE](./LICENSE).

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -87,6 +87,27 @@ node benchmarks/bench-proxy-memory-cache.js  # Test proxy with in-memory cache
 node benchmarks/bench-proxy-redis-cache.js   # Test proxy with Redis cache
 ```
 
+### V1 SCAN vs V2 Index Lookup
+
+```bash
+npm run bench:scan-vs-index
+```
+
+This benchmark measures the specific lookup-path improvement targeted by V2:
+
+- V1 lookup scans `metadata:{origin}:{path}:{method}:*`.
+- V2 lookup reads the indexed `data:v2:resource:{resourceHash}` sorted set.
+- The benchmark seeds unrelated Redis keys to model larger Redis databases.
+- The benchmark seeds multiple `Vary` variants for the same resource.
+
+Useful parameters:
+
+```bash
+UNRELATED_KEYS=100000 LOOKUPS=1000 VARIANTS=16 npm run bench:scan-vs-index
+```
+
+Output is JSON with average, p50, p95, and p99 lookup timings for V1 and V2.
+
 ## Benchmark Scenarios
 
 ### 1. No Cache (`bench-proxy-no-cache.js`)
@@ -168,7 +189,10 @@ CACHE_TYPE=redis PROXY_PORT=8080 node proxy-server.js
 
 ### Redis Cache Options
 ```javascript
-const redisCacheStore = new RedisCacheStore({
+import { createStore } from 'undici-cache-redis'
+
+const redisCacheStore = createStore({
+  prefix: 'bench:cache',
   clientOpts: {
     host: 'localhost',
     port: 6379

--- a/benchmarks/bench-proxy-memory-cache.js
+++ b/benchmarks/bench-proxy-memory-cache.js
@@ -1,8 +1,7 @@
-'use strict'
+import { pathToFileURL } from 'node:url'
+import { runProxyBenchmark } from './benchmark-utils.js'
 
-const { runProxyBenchmark } = require('./benchmark-utils')
-
-async function benchmarkProxyMemoryCache () {
+export default async function benchmarkProxyMemoryCache () {
   const result = await runProxyBenchmark({
     cacheType: 'memory',
     proxyPort: 3002,
@@ -14,8 +13,6 @@ async function benchmarkProxyMemoryCache () {
   return result
 }
 
-if (require.main === module) {
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   benchmarkProxyMemoryCache().catch(console.error)
 }
-
-module.exports = benchmarkProxyMemoryCache

--- a/benchmarks/bench-proxy-no-cache.js
+++ b/benchmarks/bench-proxy-no-cache.js
@@ -1,8 +1,7 @@
-'use strict'
+import { pathToFileURL } from 'node:url'
+import { runProxyBenchmark } from './benchmark-utils.js'
 
-const { runProxyBenchmark } = require('./benchmark-utils')
-
-async function benchmarkProxyNoCache () {
+export default async function benchmarkProxyNoCache () {
   const result = await runProxyBenchmark({
     cacheType: 'none',
     proxyPort: 3001,
@@ -14,8 +13,6 @@ async function benchmarkProxyNoCache () {
   return result
 }
 
-if (require.main === module) {
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   benchmarkProxyNoCache().catch(console.error)
 }
-
-module.exports = benchmarkProxyNoCache

--- a/benchmarks/bench-proxy-redis-cache-only.js
+++ b/benchmarks/bench-proxy-redis-cache-only.js
@@ -1,8 +1,7 @@
-'use strict'
+import { pathToFileURL } from 'node:url'
+import { runProxyBenchmark } from './benchmark-utils.js'
 
-const { runProxyBenchmark } = require('./benchmark-utils')
-
-async function benchmarkProxyRedisOnlyCache () {
+export default async function benchmarkProxyRedisOnlyCache () {
   const result = await runProxyBenchmark({
     cacheType: 'redis-only',
     proxyPort: 3003,
@@ -14,8 +13,6 @@ async function benchmarkProxyRedisOnlyCache () {
   return result
 }
 
-if (require.main === module) {
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   benchmarkProxyRedisOnlyCache().catch(console.error)
 }
-
-module.exports = benchmarkProxyRedisOnlyCache

--- a/benchmarks/bench-proxy-redis-cache-tracking.js
+++ b/benchmarks/bench-proxy-redis-cache-tracking.js
@@ -1,8 +1,7 @@
-'use strict'
+import { pathToFileURL } from 'node:url'
+import { runProxyBenchmark } from './benchmark-utils.js'
 
-const { runProxyBenchmark } = require('./benchmark-utils')
-
-async function benchmarkProxyRedisTrackingCache () {
+export default async function benchmarkProxyRedisTrackingCache () {
   const result = await runProxyBenchmark({
     cacheType: 'redis-tracking',
     proxyPort: 3003,
@@ -14,8 +13,6 @@ async function benchmarkProxyRedisTrackingCache () {
   return result
 }
 
-if (require.main === module) {
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   benchmarkProxyRedisTrackingCache().catch(console.error)
 }
-
-module.exports = benchmarkProxyRedisTrackingCache

--- a/benchmarks/bench-scan-vs-index.js
+++ b/benchmarks/bench-scan-vs-index.js
@@ -1,0 +1,124 @@
+import { once } from 'node:events'
+import { performance } from 'node:perf_hooks'
+import { Redis } from 'iovalkey'
+import { RedisCache, RedisCacheStore } from '../index.js'
+
+const REDIS_URL = process.env.REDIS_URL ?? 'redis://localhost:6379'
+const UNRELATED_KEYS = Number(process.env.UNRELATED_KEYS ?? 50000)
+const LOOKUPS = Number(process.env.LOOKUPS ?? 500)
+const VARIANTS = Number(process.env.VARIANTS ?? 8)
+
+async function writeEntry (store, key, value, body) {
+  const stream = store.createWriteStream(key, value)
+  stream.end(body)
+  await once(stream, 'close')
+}
+
+function percentile (values, p) {
+  return values[Math.floor((values.length - 1) * p)]
+}
+
+async function timeLookups (store, key) {
+  const timings = []
+
+  for (let i = 0; i < LOOKUPS; i++) {
+    const start = performance.now()
+    await store.get(key)
+    timings.push(performance.now() - start)
+  }
+
+  timings.sort((a, b) => a - b)
+  return {
+    avg: timings.reduce((acc, value) => acc + value, 0) / timings.length,
+    p50: percentile(timings, 0.50),
+    p95: percentile(timings, 0.95),
+    p99: percentile(timings, 0.99)
+  }
+}
+
+async function seedUnrelatedKeys (redis) {
+  const pipeline = redis.pipeline()
+  for (let i = 0; i < UNRELATED_KEYS; i++) {
+    pipeline.set(`bench:unrelated:${i}`, i)
+  }
+  await pipeline.exec()
+}
+
+async function seedCache (store, prefix) {
+  const value = {
+    statusCode: 200,
+    statusMessage: '',
+    headers: {},
+    cachedAt: Date.now(),
+    staleAt: Date.now() + 60_000,
+    deleteAt: Date.now() + 120_000,
+    cacheControlDirectives: {}
+  }
+
+  for (let i = 0; i < VARIANTS; i++) {
+    await writeEntry(
+      store,
+      {
+        origin: 'https://example.com',
+        method: 'GET',
+        path: '/bench',
+        headers: { vary: `${prefix}-${i}` }
+      },
+      {
+        ...value,
+        vary: { vary: `${prefix}-${i}` }
+      },
+      `${prefix}-${i}`
+    )
+  }
+}
+
+async function main () {
+  const redis = new Redis(REDIS_URL)
+  await redis.flushall()
+  await seedUnrelatedKeys(redis)
+  await redis.quit()
+
+  const v1 = new RedisCacheStore({ tracking: false, clientOpts: { keyPrefix: 'bench:v1:' } })
+  const v2 = new RedisCache({ tracking: false, prefix: 'bench:v2:' })
+
+  try {
+    await seedCache(v1, 'v1')
+    await seedCache(v2, 'v2')
+
+    const v1Key = {
+      origin: 'https://example.com',
+      method: 'GET',
+      path: '/bench',
+      headers: { vary: `v1-${VARIANTS - 1}` }
+    }
+    const v2Key = {
+      origin: 'https://example.com',
+      method: 'GET',
+      path: '/bench',
+      headers: { vary: `v2-${VARIANTS - 1}` }
+    }
+
+    await v1.get(v1Key)
+    await v2.get(v2Key)
+
+    const v1Results = await timeLookups(v1, v1Key)
+    const v2Results = await timeLookups(v2, v2Key)
+
+    console.log(JSON.stringify({
+      unrelatedKeys: UNRELATED_KEYS,
+      variants: VARIANTS,
+      lookups: LOOKUPS,
+      v1: v1Results,
+      v2: v2Results
+    }, null, 2))
+  } finally {
+    await v1.close()
+    await v2.close()
+  }
+}
+
+main().catch(err => {
+  console.error(err)
+  process.exitCode = 1
+})

--- a/benchmarks/benchmark-utils.js
+++ b/benchmarks/benchmark-utils.js
@@ -1,8 +1,6 @@
-'use strict'
-
-const autocannon = require('autocannon')
-const { spawn } = require('child_process')
-const { RedisCacheStore } = require('../index.js')
+import autocannon from 'autocannon'
+import { spawn } from 'node:child_process'
+import { RedisCacheStore } from '../index.js'
 
 const BACKEND_URL = 'http://localhost:3000'
 const DEFAULT_REQUESTS = [
@@ -22,7 +20,7 @@ for (let i = 1; i <= 500; i++) {
   KEYS_TO_DELETE.push({ origin: BACKEND_URL, method: 'GET', path: `/api/products/${i}` })
 }
 
-async function waitForServer (url, maxAttempts = 30) {
+export async function waitForServer (url, maxAttempts = 30) {
   for (let i = 0; i < maxAttempts; i++) {
     try {
       const response = await fetch(`${url}/health`)
@@ -37,7 +35,7 @@ async function waitForServer (url, maxAttempts = 30) {
   throw new Error(`Server failed to start at ${url}`)
 }
 
-async function clearRedisCache () {
+export async function clearRedisCache () {
   try {
     const redisCacheStore = new RedisCacheStore({
       clientOpts: {
@@ -54,7 +52,7 @@ async function clearRedisCache () {
   }
 }
 
-async function warmupCache (proxyUrl) {
+export async function warmupCache (proxyUrl) {
   try {
     // Use fetch to warm up through the proxy which should use the same cache
     for (const request of DEFAULT_REQUESTS) {
@@ -70,7 +68,7 @@ async function warmupCache (proxyUrl) {
   }
 }
 
-function formatResults (result, scenarioName) {
+export function formatResults (result, scenarioName) {
   return `
 Results (${scenarioName}):
   Requests/sec: ${result.requests.average}
@@ -82,7 +80,7 @@ Results (${scenarioName}):
   `
 }
 
-async function runProxyBenchmark (options = {}) {
+export async function runProxyBenchmark (options = {}) {
   const {
     cacheType = 'none',
     proxyPort = 3001,
@@ -147,12 +145,4 @@ async function runProxyBenchmark (options = {}) {
   }
 }
 
-module.exports = {
-  runProxyBenchmark,
-  waitForServer,
-  clearRedisCache,
-  warmupCache,
-  formatResults,
-  DEFAULT_REQUESTS,
-  BACKEND_URL
-}
+export { BACKEND_URL, DEFAULT_REQUESTS }

--- a/benchmarks/proxy-server.js
+++ b/benchmarks/proxy-server.js
@@ -1,8 +1,6 @@
-'use strict'
-
-const fastify = require('fastify')
-const { Agent, interceptors } = require('undici')
-const { RedisCacheStore } = require('../index.js')
+import fastify from 'fastify'
+import { Agent, interceptors } from 'undici'
+import { RedisCacheStore } from '../index.js'
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:3000'
 const PORT = process.env.PROXY_PORT || 3001

--- a/benchmarks/run-proxy-benchmarks.js
+++ b/benchmarks/run-proxy-benchmarks.js
@@ -1,9 +1,8 @@
-'use strict'
-
-const benchProxyNoCache = require('./bench-proxy-no-cache')
-const benchProxyMemoryCache = require('./bench-proxy-memory-cache')
-const benchProxyRedisOnlyCache = require('./bench-proxy-redis-cache-only')
-const benchProxyRedisTrackingCache = require('./bench-proxy-redis-cache-tracking')
+import { pathToFileURL } from 'node:url'
+import benchProxyMemoryCache from './bench-proxy-memory-cache.js'
+import benchProxyNoCache from './bench-proxy-no-cache.js'
+import benchProxyRedisOnlyCache from './bench-proxy-redis-cache-only.js'
+import benchProxyRedisTrackingCache from './bench-proxy-redis-cache-tracking.js'
 
 function formatValue (value, decimals = 2) {
   return value ? value.toFixed(decimals) : 'N/A'
@@ -19,7 +18,7 @@ function calculateReduction (baseline, current) {
   return (((baseline - current) / baseline) * 100).toFixed(1)
 }
 
-async function runAllBenchmarks () {
+export default async function runAllBenchmarks () {
   console.log('🚀 Running All Proxy Benchmarks')
   console.log('='.repeat(60))
   console.log('Architecture: Autocannon -> Server FOO (proxy) -> Server Bar (backend)')
@@ -120,8 +119,6 @@ async function runAllBenchmarks () {
   }
 }
 
-if (require.main === module) {
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   runAllBenchmarks()
 }
-
-module.exports = runAllBenchmarks

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,0 +1,3 @@
+# Data Model
+
+See [v2-data-model.md](./v2-data-model.md).

--- a/docs/migration-v2.md
+++ b/docs/migration-v2.md
@@ -1,0 +1,169 @@
+# Migrating To V2
+
+V2 is the default API for the next major release. It keeps V1 cache semantics, but changes the public API shape and Redis data model.
+
+## Main Changes
+
+- The default export is now `RedisCache`.
+- `createStore()` and `createManager()` both return a V2 `RedisCache` instance.
+- Store and manager operations are available on the same object.
+- V2 uses hash-tagged `data:v2` keys and does not read V1 cache data.
+- V2 keys are Redis Cluster hash-tagged. Prefixes containing `{` or `}` are rejected.
+- V2 requires Redis >= 7.0 or Valkey >= 8.0.
+- V2 avoids `SCAN` on HTTP cache lookup.
+- Tag index keys are hashed. Original tag names remain in entry metadata.
+
+## Basic Usage
+
+V1:
+
+```js
+import { RedisCacheStore } from 'undici-cache-redis'
+
+const store = new RedisCacheStore({
+  clientOpts: {
+    keyPrefix: 'my-app:cache:'
+  }
+})
+```
+
+V2:
+
+```js
+import RedisCache from 'undici-cache-redis'
+
+const store = new RedisCache({
+  prefix: 'my-app:cache'
+})
+```
+
+Or with the factory:
+
+```js
+import { createStore } from 'undici-cache-redis'
+
+const store = createStore({
+  prefix: 'my-app:cache'
+})
+```
+
+## Prefixes
+
+V1 used `clientOpts.keyPrefix`.
+
+V2 prefers `prefix`:
+
+```js
+const cache = createStore({ prefix: 'my-app:cache' })
+```
+
+`clientOpts.keyPrefix` is still accepted as a migration convenience, but new V2 code should use `prefix`.
+
+If `clusterId` is provided, it is used as the Redis Cluster hash tag:
+
+```js
+const cache = createStore({
+  prefix: 'my-app:cache',
+  clusterId: 'tenant-a'
+})
+```
+
+## Manager Operations
+
+V1 used two classes:
+
+```js
+import { RedisCacheManager, RedisCacheStore } from 'undici-cache-redis'
+
+const store = new RedisCacheStore(storeOptions)
+const manager = new RedisCacheManager(managerOptions)
+```
+
+V2 uses one class:
+
+```js
+import { createStore } from 'undici-cache-redis'
+
+const cache = createStore(options)
+
+await cache.streamEntries(entry => {
+  console.log(entry.id, entry.origin, entry.path)
+})
+
+await cache.deleteIds(['entry-id'])
+await cache.getResponseById('entry-id')
+```
+
+`createManager()` exists for readability, but returns the same V2 class:
+
+```js
+import { createManager } from 'undici-cache-redis'
+
+const manager = createManager(options)
+```
+
+## Deletion Semantics
+
+V2 preserves the important V1 semantics:
+
+- `delete(key)` deletes by `origin + path`, across all methods.
+- `deleteKeys(keys)` deletes by exact `origin + method + path`, or by `id` if present.
+- `deleteTags(tags)` deletes entries matching a tag or tag combination.
+- `deleteIds(ids)` deletes entries by id.
+
+V2 also adds generic indexed operations:
+
+```js
+await cache.entries({ origin })
+await cache.entries({ origin, method })
+await cache.entries({ origin, path })
+await cache.entries({ origin, method, path })
+
+await cache.deleteEntries({ origin, method, path })
+```
+
+## V1 Compatibility
+
+V1 remains available:
+
+```js
+import {
+  RedisCacheStore,
+  RedisCacheManager,
+  createStore,
+  createManager
+} from 'undici-cache-redis'
+
+const store = new RedisCacheStore(options)
+const manager = new RedisCacheManager(options)
+
+const sameStore = createStore(options, '1.0.0')
+const sameManager = createManager(options, '1.0.0')
+```
+
+## Data Compatibility
+
+V1 and V2 data coexist but are independent.
+
+- V1 keys use `metadata:*`, `values:*`, `ids:*`, and `cache-tags:*`.
+- V2 keys use hash-tagged `data:v2` namespaces, such as `{my-app:cache:data:v2}:*`.
+
+There is no automatic migration from V1 data to V2 data. Existing V1 cache entries should be treated as disposable cache state.
+
+## Events
+
+V1 manager events:
+
+- `add-entry`
+- `delete-entry`
+
+V2 subscription events:
+
+- `subscription:entry:add`
+- `subscription:entry:delete`
+
+V2 local events:
+
+- `entry:write`
+- `entry:delete`
+- `tag:delete`

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,3 @@
+# Migration
+
+See [migration-v2.md](./migration-v2.md).

--- a/docs/v1.md
+++ b/docs/v1.md
@@ -1,0 +1,256 @@
+# V1 API
+
+V1 is still available through the legacy classes and through the versioned factories.
+
+```js
+import { RedisCacheManager, RedisCacheStore, createManager, createStore } from 'undici-cache-redis'
+
+const store = new RedisCacheStore(options)
+const sameStore = createStore(options, '1.0.0')
+
+const manager = new RedisCacheManager(options)
+const sameManager = createManager(options, '1.0.0')
+```
+
+## Requirements
+
+- Node.js >= 20
+- Redis >= 6.0 or Valkey >= 7.2
+- Undici >= 7.0
+
+## Quick Start
+
+```js
+import { Agent, interceptors } from 'undici'
+import { RedisCacheStore } from 'undici-cache-redis'
+
+const store = new RedisCacheStore({
+  clientOpts: {
+    host: 'localhost',
+    port: 6379,
+    keyPrefix: 'my-app:cache:'
+  }
+})
+
+const agent = new Agent().compose(interceptors.cache({ store }))
+
+const response = await agent.request({
+  origin: 'https://api.example.com',
+  method: 'GET',
+  path: '/users/123'
+})
+
+console.log(await response.body.text())
+```
+
+## Using With Fetch
+
+```js
+import { Agent, interceptors, setGlobalDispatcher } from 'undici'
+import { RedisCacheStore } from 'undici-cache-redis'
+
+const store = new RedisCacheStore()
+const agent = new Agent().compose(interceptors.cache({ store }))
+
+setGlobalDispatcher(agent)
+
+const response = await fetch('https://api.example.com/users/123')
+const data = await response.json()
+
+if (response.headers.get('x-cache') === 'HIT') {
+  console.log('Response was served from cache')
+}
+```
+
+## Cache Tags
+
+```js
+import { Agent, interceptors } from 'undici'
+import { RedisCacheStore } from 'undici-cache-redis'
+
+const store = new RedisCacheStore({
+  cacheTagsHeader: 'cache-tags'
+})
+
+const agent = new Agent().compose(interceptors.cache({ store }))
+
+await agent.request({
+  origin: 'https://api.example.com',
+  method: 'GET',
+  path: '/users/123'
+})
+
+await store.deleteTags(['user:123'])
+```
+
+If the origin responds with `Cache-Tags: user:123,profile`, `deleteTags(['user:123'])` removes matching cached responses.
+
+## Vary Headers
+
+```js
+const store = new RedisCacheStore()
+const agent = new Agent().compose(interceptors.cache({ store }))
+
+await agent.request({
+  origin: 'https://api.example.com',
+  method: 'GET',
+  path: '/content',
+  headers: { 'Accept-Language': 'en' }
+})
+
+await agent.request({
+  origin: 'https://api.example.com',
+  method: 'GET',
+  path: '/content',
+  headers: { 'Accept-Language': 'fr' }
+})
+```
+
+## RedisCacheStore
+
+### Options
+
+```ts
+interface RedisCacheStoreOpts {
+  clientConfigTracking?: boolean
+  clientOpts?: RedisOptions
+  maxEntrySize?: number
+  maxSize?: number
+  maxCount?: number
+  tracking?: boolean
+  cacheTagsHeader?: string
+  errorCallback?: (err: Error) => void
+}
+```
+
+### Methods
+
+- `get(key)` retrieves a cached response.
+- `createWriteStream(key, value)` creates a write stream for a response.
+- `delete(key)` deletes entries for `origin + path`, across all methods.
+- `deleteKeys(keys)` deletes entries for each `origin + method + path` key.
+- `deleteTags(tags)` deletes entries matching tags or tag combinations.
+- `close()` closes Redis connections.
+
+### Manual Operations
+
+```js
+const store = new RedisCacheStore()
+
+await store.deleteKeys([
+  { origin: 'https://api.example.com', method: 'GET', path: '/users/123' }
+])
+
+await store.deleteTags(['user:123', 'profile'])
+await store.close()
+```
+
+### Events
+
+- `write` is emitted when an entry is written.
+
+## RedisCacheManager
+
+### Options
+
+```ts
+interface RedisCacheManagerOpts {
+  clientConfigKeyspaceEventNotify?: boolean
+  clientOpts?: RedisOptions
+}
+```
+
+### Methods
+
+- `streamEntries(callback, keyPrefix)` streams all entries for a prefix.
+- `subscribe()` subscribes to Redis keyspace events.
+- `getResponseById(id, keyPrefix)` returns a decoded response body.
+- `getDependentEntries(id, keyPrefix)` returns entries sharing cache tags.
+- `deleteIds(ids, keyPrefix)` deletes entries by id.
+- `close()` closes Redis connections.
+
+### Events
+
+- `add-entry` is emitted when an entry is added.
+- `delete-entry` is emitted when an entry is deleted or expires.
+- `error` is emitted on subscription/manager errors.
+
+### Management Example
+
+```js
+const manager = new RedisCacheManager({
+  clientOpts: { host: 'localhost', port: 6379 }
+})
+
+await manager.subscribe()
+
+manager.on('add-entry', entry => {
+  console.log('Cache entry added:', entry.path, entry.cacheTags)
+})
+
+manager.on('delete-entry', ({ id, keyPrefix }) => {
+  console.log('Cache entry deleted:', id, keyPrefix)
+})
+
+const entriesToDelete = []
+
+await manager.streamEntries(entry => {
+  if (entry.path.startsWith('/api/products/')) {
+    entriesToDelete.push(entry.id)
+  }
+}, 'my-app:cache:')
+
+await manager.deleteIds(entriesToDelete, 'my-app:cache:')
+
+const responseBody = await manager.getResponseById('entry-id', 'my-app:cache:')
+```
+
+## Error Handling
+
+```js
+const store = new RedisCacheStore({
+  errorCallback: err => {
+    console.error('Cache error:', err.message)
+  }
+})
+```
+
+## Managed Redis Services
+
+When `CONFIG SET` is restricted, disable automatic keyspace event configuration:
+
+```js
+const manager = new RedisCacheManager({
+  clientConfigKeyspaceEventNotify: false,
+  clientOpts: {
+    host: 'your-cluster.cache.amazonaws.com',
+    port: 6379,
+    family: 4,
+    enableReadyCheck: false
+  }
+})
+```
+
+If you use `subscribe()`, configure keyspace notifications externally:
+
+```text
+notify-keyspace-events = AKE
+```
+
+## Performance Notes
+
+- Client-side tracking is enabled by default.
+- Redis pipelining is used for batch operations.
+- Binary response data is supported.
+- `maxEntrySize`, `maxSize`, and `maxCount` can limit memory usage.
+
+## Redis Key Structure
+
+V1 stores data with these keys:
+
+- `{prefix}metadata:{origin}:{path}:{method}:{id}`
+- `{prefix}values:{id}`
+- `{prefix}ids:{id}`
+- `{prefix}cache-tags:{tag1}:{tag2}:{id}`
+
+V1 uses `SCAN` for several lookup and management paths. V2 replaces the hot-path lookup with indexed sorted sets.

--- a/docs/v2-data-model.md
+++ b/docs/v2-data-model.md
@@ -1,0 +1,194 @@
+# V2 Data Model
+
+## Goals
+
+- Support the V1 cache semantics without preserving the V1 API shape.
+- Collapse store and manager behavior into one `RedisCache` class.
+- Avoid `SCAN` on the HTTP cache hot path.
+- Keep package/API version separate from data schema version.
+- Support prefixes/namespaces for every key.
+- Target Redis 7 or Valkey 8 and use concise command syntax where available.
+
+## Versioning
+
+The data version is implicit in the Redis key namespace:
+
+```text
+data:v2
+```
+
+The package/API version can change independently in the future. There is no public data-version option.
+
+## Cluster Hash Tags
+
+V2 keys are Redis Cluster hash-tagged.
+
+Without `clusterId`, the hash tag is `prefix + data:v2`:
+
+```text
+{my-app:cache:data:v2}:entry:{id}
+```
+
+With `clusterId`, only the cluster id is hash-tagged:
+
+```text
+my-app:cache:{tenant-a}:data:v2:entry:{id}
+```
+
+With an empty prefix, keys do not start with `:`:
+
+```text
+{data:v2}:entry:{id}
+{tenant-a}:data:v2:entry:{id}
+```
+
+`prefix` and `clusterId` cannot contain `{` or `}`. `prefix` can be empty. `clusterId`, if provided, cannot be empty.
+
+## Hashing
+
+V2 uses `xxhash-wasm` for fast deterministic hashes.
+
+```text
+originHash = hash(origin)
+originMethodHash = hash([origin, method])
+originPathHash = hash([origin, path])
+resourceHash = hash([origin, method, path])
+varyHash = hash(normalizedVary)
+tagHash = hash(tag)
+```
+
+Hashes are identifiers only. Original `origin`, `method`, `path`, `vary`, and tag values are stored in entry metadata.
+
+## Keys
+
+Payload keys:
+
+```text
+{namespace}:entry:{id}
+{namespace}:body:{id}
+```
+
+Primary resource bucket:
+
+```text
+{namespace}:resource:{resourceHash}
+```
+
+Search/delete indexes:
+
+```text
+{namespace}:index:all
+{namespace}:index:origin:{originHash}
+{namespace}:index:origin-method:{originMethodHash}
+{namespace}:index:origin-path:{originPathHash}
+{namespace}:index:resource:{resourceHash}
+```
+
+Tag index:
+
+```text
+{namespace}:tag:{tagHash}
+```
+
+All index keys and resource buckets are sorted sets:
+
+```text
+member = id
+score = deleteAtSeconds
+```
+
+## Entry Metadata
+
+```js
+{
+  id,
+  prefix,
+  origin,
+  method,
+  path,
+  originHash,
+  originMethodHash,
+  originPathHash,
+  resourceHash,
+  varyHash,
+  vary,
+  specificity,
+  tags,
+  tagHashes,
+  statusCode,
+  statusMessage,
+  headers,
+  cachedAt,
+  staleAt,
+  deleteAt,
+  cacheControlDirectives
+}
+```
+
+## Expiration
+
+Payload keys use hard Redis expiry:
+
+```text
+SET entry:{id} json EXAT deleteAt
+SET body:{id} body EXAT deleteAt
+```
+
+Indexes and resource buckets expire at the latest member `deleteAt`:
+
+```text
+ZADD index deleteAt id
+EXPIREAT index deleteAt NX
+EXPIREAT index deleteAt GT
+```
+
+Reads, writes, and deletes clean touched indexes with:
+
+```text
+ZREMRANGEBYSCORE index -inf now
+```
+
+This means expired entries are never returned, hot indexes stay compact, and cold indexes disappear automatically.
+
+## HTTP Lookup
+
+`get(key)` computes `resourceHash`, reads live ids from the resource bucket, hydrates entry metadata, filters by `Vary`, chooses the most specific match, then reads the selected body.
+
+Same `resourceHash + varyHash` replaces the previous entry. Different `varyHash` values coexist.
+
+## Search And Delete Levels
+
+V2 supports these indexed levels:
+
+- all
+- origin
+- origin + method
+- origin + path
+- origin + method + path
+- id
+- tags
+
+V1 `delete(key)` maps to `origin + path`, across all methods.
+
+V1 `deleteKeys(keys)` maps to `origin + method + path`.
+
+## Commands
+
+The V2 data path uses common Redis 7 / Valkey 8 commands:
+
+- `GET`
+- `MGET`
+- `SET ... EXAT`
+- `DEL`
+- `ZADD`
+- `ZREM`
+- `ZRANGEBYSCORE`
+- `ZREMRANGEBYSCORE`
+- `EXPIREAT ... NX`
+- `EXPIREAT ... GT`
+
+`SCAN` is not used for HTTP lookup.
+
+## Subscriptions
+
+V2 uses separate Redis clients for client-side tracking invalidations and keyspace notifications. This keeps `CLIENT TRACKING` traffic independent from manager-style `subscribe()` events.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,5 @@
-'use strict'
+import neostandard from 'neostandard'
 
-module.exports = require('neostandard')({
+export default neostandard({
   files: ['**.js']
 })

--- a/example/advanced-client.js
+++ b/example/advanced-client.js
@@ -1,8 +1,6 @@
-'use strict'
-
-const { Agent, interceptors, setGlobalDispatcher } = require('undici')
-const { RedisCacheStore, RedisCacheManager } = require('../index.js')
-const { promisify } = require('util')
+import { promisify } from 'node:util'
+import { Agent, interceptors, setGlobalDispatcher } from 'undici'
+import { RedisCacheManager, RedisCacheStore } from '../index.js'
 
 const sleep = promisify(setTimeout)
 const API_BASE_URL = 'http://localhost:3000'

--- a/example/cache-manager-example.js
+++ b/example/cache-manager-example.js
@@ -1,7 +1,5 @@
-'use strict'
-
-const { Agent, interceptors, setGlobalDispatcher } = require('undici')
-const { RedisCacheStore, RedisCacheManager } = require('../index.js')
+import { Agent, interceptors, setGlobalDispatcher } from 'undici'
+import { RedisCacheManager, RedisCacheStore } from '../index.js'
 
 const API_BASE_URL = 'http://localhost:3000'
 

--- a/example/client.js
+++ b/example/client.js
@@ -1,7 +1,5 @@
-'use strict'
-
-const { Agent, interceptors, setGlobalDispatcher } = require('undici')
-const { RedisCacheStore, RedisCacheManager } = require('../index.js')
+import { Agent, interceptors, setGlobalDispatcher } from 'undici'
+import { RedisCacheManager, RedisCacheStore } from '../index.js'
 
 const API_BASE_URL = 'http://localhost:3000'
 

--- a/example/server.js
+++ b/example/server.js
@@ -1,7 +1,5 @@
-'use strict'
-
-const fastify = require('fastify')
-const sleep = require('atomic-sleep')
+import sleep from 'atomic-sleep'
+import fastify from 'fastify'
 
 const app = fastify()
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,86 +1,26 @@
-import { EventEmitter, Writable } from "node:stream";
-import { RedisOptions } from "iovalkey";
-import { GetResult, CacheKey, CachedResponse } from "./lib/internal-types";
-
-export interface RedisCacheStoreOpts {
-  clientConfigTracking?: boolean
-
-  clientOpts?: RedisOptions
-  
-  maxEntrySize?: number
-
-  maxSize?: number
-
-  maxCount?: number
-  
-  /**
-   * Redis client-side caching
-   * @see https://redis.io/docs/latest/develop/reference/client-side-caching/
-   * @default true
-   */
-  tracking?: boolean
-  
-  cacheTagsHeader?: string
-
-  errorCallback?: (err: Error) => void
-}
-
-export interface RedisCacheManagerOpts {
-  clientConfigKeyspaceEventNotify?: boolean
-
-  clientOpts?: RedisOptions
-}
-
-declare class RedisCacheStore extends EventEmitter {
-  constructor(opts?: RedisCacheStoreOpts);
-
-  get(key: CacheKey): Promise<GetResult | undefined>
-
-  createWriteStream(key: CacheKey, value: CachedResponse): Writable
-
-  delete(key: CacheKey): Promise<void>
-
-  deleteKeys(keys: CacheKey[]): Promise<void>
-
-  deleteTags(tags: string[]): Promise<void>
-
-  close(): Promise<void>
-}
-
-export interface CacheEntry {
-  id: string;
-  keyPrefix: string;
-  origin: string;
-  path: string;
-  method: string;
-  statusCode: number;
-  headers: Record<string, string | string[]>;
-  cacheTags: string[];
-  cachedAt: number;
-  staleAt: number;
-  deleteAt: number;
-}
-
-declare class RedisCacheManager extends EventEmitter{
-  constructor(opts?: RedisCacheManagerOpts);
-
-  streamEntries(
-    callback: (entry: CacheEntry) => Promise<unknown> | unknown,
-    keyPrefix: string,
-  ): Promise<void>
-
-  subscribe(): Promise<void>
-
-  getResponseById(id: string, keyPrefix: string): Promise<string | null>
-
-  getDependentEntries(id: string, keyPrefix: string): Promise<CacheEntry[]>
-
-  deleteIds (ids: string[], keyPrefix: string): Promise<void>
-
-  close(): Promise<void>
-}
-
 export {
   RedisCacheStore,
-  RedisCacheManager
-}
+  RedisCacheManager,
+  RedisCacheStoreOpts,
+  RedisCacheManagerOpts,
+  CacheEntry
+} from './src/v1'
+
+export {
+  RedisCache,
+  RedisCacheOpts,
+  RedisCacheEntry,
+  RedisCacheFilter
+} from './src/v2'
+
+export { default } from './src/v2'
+
+export { GetResult, CacheKey, CachedResponse } from './src/common/internal-types'
+
+import { RedisCacheStore, RedisCacheManager, RedisCacheStoreOpts, RedisCacheManagerOpts } from './src/v1'
+import { RedisCache, RedisCacheOpts } from './src/v2'
+
+export function createStore(opts?: RedisCacheOpts): RedisCache
+export function createStore(opts: RedisCacheStoreOpts | undefined, version: '1.0.0' | '1'): RedisCacheStore
+export function createManager(opts?: RedisCacheOpts): RedisCache
+export function createManager(opts: RedisCacheManagerOpts | undefined, version: '1.0.0' | '1'): RedisCacheManager

--- a/index.js
+++ b/index.js
@@ -1,7 +1,21 @@
-'use strict'
+import RedisCache from './src/v2/cache.js'
+import { RedisCacheManager, RedisCacheStore } from './src/v1/redis-cache-store.js'
 
-const { RedisCacheStore, RedisCacheManager } = require('./lib/redis-cache-store')
+export function createStore (opts, version) {
+  if (version === '1.0.0' || version === '1') {
+    return new RedisCacheStore(opts)
+  }
 
-module.exports = RedisCacheStore
-module.exports.RedisCacheStore = RedisCacheStore
-module.exports.RedisCacheManager = RedisCacheManager
+  return new RedisCache(opts)
+}
+
+export function createManager (opts, version) {
+  if (version === '1.0.0' || version === '1') {
+    return new RedisCacheManager(opts)
+  }
+
+  return new RedisCache(opts)
+}
+
+export { RedisCache, RedisCacheManager, RedisCacheStore }
+export default RedisCache

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "license": "Apache-2.0",
       "dependencies": {
         "iovalkey": "^0.3.3",
-        "lru_map": "^0.4.1"
+        "lru_map": "^0.4.1",
+        "p-map": "^7.0.4",
+        "xxhash-wasm": "^1.1.0"
       },
       "devDependencies": {
         "@types/node": "^24.0.0",
@@ -4459,6 +4461,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-map": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -6212,6 +6226,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xxhash-wasm": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
+      "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -2,15 +2,19 @@
   "name": "undici-cache-redis",
   "version": "1.0.1",
   "description": "An Undici cache store with a Redis backend.",
-  "main": "index.js",
-  "directories": {
-    "lib": "lib"
+  "type": "module",
+  "main": "./index.js",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.js"
+    }
   },
   "scripts": {
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "valkey": "docker compose up -d",
-    "test": "node --test --test-concurrency=1 ./test/*.test.js",
+    "test": "node --test --test-concurrency=1 ./test/v1/*.test.js ./test/v2/*.test.js ./test/v2/compatibility/*.test.js",
     "test:typescript": "tsd --files test/ && tsc ./index.d.ts --noEmit",
     "example:server": "node example/server.js",
     "example:client": "node example/client.js",
@@ -18,7 +22,8 @@
     "example:docker:up": "cd example && docker-compose up -d",
     "example:docker:down": "cd example && docker-compose down",
     "example:run": "cd example && ./run-example.sh",
-    "bench": "./benchmarks/run-benchmarks.sh"
+    "bench": "./benchmarks/run-benchmarks.sh",
+    "bench:scan-vs-index": "node benchmarks/bench-scan-vs-index.js"
   },
   "repository": {
     "type": "git",
@@ -38,17 +43,19 @@
   "homepage": "https://github.com/platformatic/undici-cache-redis#readme",
   "dependencies": {
     "iovalkey": "^0.3.3",
-    "lru_map": "^0.4.1"
+    "lru_map": "^0.4.1",
+    "p-map": "^7.0.4",
+    "xxhash-wasm": "^1.1.0"
   },
   "devDependencies": {
-    "atomic-sleep": "^1.0.0",
     "@types/node": "^24.0.0",
+    "atomic-sleep": "^1.0.0",
+    "autocannon": "^8.0.0",
     "eslint": "^9.32.0",
+    "fastify": "^5.4.0",
     "neostandard": "^0.13.0",
     "tsd": "^0.33.0",
     "typescript": "^5.9.2",
-    "undici": "^7.13.0",
-    "fastify": "^5.4.0",
-    "autocannon": "^8.0.0"
+    "undici": "^7.13.0"
   }
 }

--- a/src/common/internal-types.d.ts
+++ b/src/common/internal-types.d.ts
@@ -1,6 +1,4 @@
-import { Writable, Readable } from "node:stream";
-
-// TODO: delete this file when the types land in v7
+import { Writable, Readable } from 'node:stream'
 
 export interface CacheKey {
   id?: string
@@ -18,13 +16,7 @@ export interface DeleteByUri {
 
 export type GetResult = CachedResponse & { body: undefined | Readable | Iterable<Buffer> | Buffer | Iterable<string> | string }
 
-/**
- * Underlying storage provider for cached responses
- */
 export interface CacheStore {
-  /**
-   * Whether or not the cache is full and can not store any more responses
-   */
   readonly isFull?: boolean
 
   get(key: CacheKey): GetResult | Promise<GetResult | undefined> | undefined
@@ -33,30 +25,16 @@ export interface CacheStore {
 
   delete(key: CacheKey): void | Promise<void>
 
-  deleteKeys(keys: CacheKey[]): void | Promise<void>;
+  deleteKeys(keys: CacheKey[]): void | Promise<void>
 }
 
 export interface CachedResponse {
-  statusCode: number;
-  statusMessage: string;
+  statusCode: number
+  statusMessage: string
   headers: Record<string, string | string[]>
-  /**
-   * Headers defined by the Vary header and their respective values for
-   *  later comparison
-   */
   vary?: Record<string, string | string[]>
-  /**
-   * Time in millis that this value was cached
-   */
   cachedAt: number
-  /**
-   * Time in millis that this value is considered stale
-   */
   staleAt: number
-  /**
-   * Time in millis that this value is to be deleted from the cache. This is
-   *  either the same as staleAt or the `max-stale` caching directive.
-   */
   deleteAt: number
   cacheControlDirectives: Record<string, string | string[]>
 }

--- a/src/v1/index.d.ts
+++ b/src/v1/index.d.ts
@@ -1,0 +1,66 @@
+import { EventEmitter } from 'node:events'
+import { Writable } from 'node:stream'
+import { RedisOptions } from 'iovalkey'
+import { GetResult, CacheKey, CachedResponse } from '../common/internal-types'
+
+export interface RedisCacheStoreOpts {
+  clientConfigTracking?: boolean
+  clientOpts?: RedisOptions
+  maxEntrySize?: number
+  maxSize?: number
+  maxCount?: number
+  tracking?: boolean
+  cacheTagsHeader?: string
+  errorCallback?: (err: Error) => void
+}
+
+export interface RedisCacheManagerOpts {
+  clientConfigKeyspaceEventNotify?: boolean
+  clientOpts?: RedisOptions
+}
+
+export declare class RedisCacheStore extends EventEmitter {
+  constructor(opts?: RedisCacheStoreOpts)
+
+  get(key: CacheKey): Promise<GetResult | undefined>
+
+  createWriteStream(key: CacheKey, value: CachedResponse): Writable
+
+  delete(key: CacheKey): Promise<void>
+
+  deleteKeys(keys: CacheKey[]): Promise<void>
+
+  deleteTags(tags: string[]): Promise<void>
+
+  close(): Promise<void>
+}
+
+export interface CacheEntry {
+  id: string
+  keyPrefix: string
+  origin: string
+  path: string
+  method: string
+  statusCode: number
+  headers: Record<string, string | string[]>
+  cacheTags: string[]
+  cachedAt: number
+  staleAt: number
+  deleteAt: number
+}
+
+export declare class RedisCacheManager extends EventEmitter {
+  constructor(opts?: RedisCacheManagerOpts)
+
+  streamEntries(callback: (entry: CacheEntry) => Promise<unknown> | unknown, keyPrefix: string): Promise<void>
+
+  subscribe(): Promise<void>
+
+  getResponseById(id: string, keyPrefix: string): Promise<string | null>
+
+  getDependentEntries(id: string, keyPrefix: string): Promise<CacheEntry[]>
+
+  deleteIds(ids: string[], keyPrefix: string): Promise<void>
+
+  close(): Promise<void>
+}

--- a/src/v1/index.js
+++ b/src/v1/index.js
@@ -1,0 +1,1 @@
+export { RedisCacheManager, RedisCacheStore } from './redis-cache-store.js'

--- a/src/v1/internal-types.d.ts
+++ b/src/v1/internal-types.d.ts
@@ -1,0 +1,1 @@
+export * from '../common/internal-types'

--- a/src/v1/redis-cache-store.js
+++ b/src/v1/redis-cache-store.js
@@ -1,11 +1,10 @@
 // @ts-check
-'use strict'
 
-const { EventEmitter, setMaxListeners } = require('node:events')
-const { Writable } = require('node:stream')
-const { setTimeout: sleep } = require('node:timers/promises')
-const { Redis } = require('iovalkey')
-const TrackingCache = require('./tracking-cache.js')
+import { EventEmitter, setMaxListeners } from 'node:events'
+import { Writable } from 'node:stream'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { Redis } from 'iovalkey'
+import TrackingCache from './tracking-cache.js'
 
 /**
  * @typedef {{
@@ -44,7 +43,7 @@ const TrackingCache = require('./tracking-cache.js')
  * @typedef {import('./internal-types.d.ts').CacheStore} CacheStore
  * @implements {CacheStore}
  */
-class RedisCacheStore extends EventEmitter {
+export class RedisCacheStore extends EventEmitter {
   #maxEntrySize = Infinity
 
   /**
@@ -101,7 +100,7 @@ class RedisCacheStore extends EventEmitter {
   #context
 
   /**
-   * @param {import('../index.d.ts').RedisCacheStoreOpts | undefined} opts
+   * @param {import('../../index.d.ts').RedisCacheStoreOpts | undefined} opts
    */
   constructor (opts) {
     super()
@@ -659,7 +658,7 @@ class RedisCacheStore extends EventEmitter {
   }
 }
 
-class RedisCacheManager extends EventEmitter {
+export class RedisCacheManager extends EventEmitter {
   /**
    * @type {import('iovalkey').Redis}
    */
@@ -701,7 +700,7 @@ class RedisCacheManager extends EventEmitter {
   #clientConfigKeyspaceEventNotify
 
   /**
-   * @param {import('../index.d.ts').RedisCacheManagerOpts | undefined} opts
+    * @param {import('../../index.d.ts').RedisCacheManagerOpts | undefined} opts
    */
   constructor (opts) {
     super()
@@ -737,7 +736,7 @@ class RedisCacheManager extends EventEmitter {
   }
 
   /**
-   * @param {(entry: import('../index.d.ts').CacheEntry) => Promise<unknown> | unknown} callback
+    * @param {(entry: import('../../index.d.ts').CacheEntry) => Promise<unknown> | unknown} callback
    * @param {string} keyPrefix
    * @returns {Promise<void>}
    */
@@ -841,7 +840,7 @@ class RedisCacheManager extends EventEmitter {
   /**
    * @param {string} id
    * @param {string} keyPrefix
-   * @returns {Promise<import('../index.d.ts').CacheEntry[]>}
+    * @returns {Promise<import('../../index.d.ts').CacheEntry[]>}
    */
   async getDependentEntries (id, keyPrefix = '') {
     const { metadataKey } = await this.#redis.hgetall(`${keyPrefix}ids:${id}`)
@@ -909,7 +908,7 @@ class RedisCacheManager extends EventEmitter {
   /**
    * @param {string} idKey
    * @param {string} keyPrefix
-   * @returns {Promise<import('../index.d.ts').CacheEntry | undefined>}
+    * @returns {Promise<import('../../index.d.ts').CacheEntry | undefined>}
    */
   async #getEntryByIdKey (idKey, keyPrefix = '') {
     const { metadataKey } = await this.#redis.hgetall(
@@ -923,7 +922,7 @@ class RedisCacheManager extends EventEmitter {
   /**
    * @param {string} tagsKey
    * @param {string} keyPrefix
-   * @returns {Promise<import('../index.d.ts').CacheEntry | undefined>}
+    * @returns {Promise<import('../../index.d.ts').CacheEntry | undefined>}
    */
   async #getEntryByTagsKey (tagsKey, keyPrefix = '') {
     const { metadataKey } = await this.#redis.hgetall(
@@ -937,7 +936,7 @@ class RedisCacheManager extends EventEmitter {
   /**
    * @param {string} metadataKey
    * @param {string} keyPrefix
-   * @returns {Promise<import('../index.d.ts').CacheEntry | undefined>}
+    * @returns {Promise<import('../../index.d.ts').CacheEntry | undefined>}
    */
   async #getEntryByMetadataKey (metadataKey, keyPrefix = '') {
     const { id } = parseMetadataKey(metadataKey)
@@ -1230,7 +1229,5 @@ function parseBufferArray (strings) {
   return output
 }
 
-module.exports = { RedisCacheStore, RedisCacheManager }
-
 // exported for unittests only.
-module.exports._scanByPattern = scanByPattern
+export { scanByPattern as _scanByPattern }

--- a/src/v1/tracking-cache.js
+++ b/src/v1/tracking-cache.js
@@ -1,8 +1,8 @@
-'use strict'
+import lruMap from 'lru_map'
 
-const { LRUMap } = require('lru_map')
+const { LRUMap } = lruMap
 
-class TrackingCache {
+export default class TrackingCache {
   /**
    * @type {LRUMap}
    */
@@ -163,5 +163,3 @@ function serializeTackingMetadataKey (key) {
   const encodedPath = encodeURIComponent(path)
   return `${encodedOrigin}:${encodedPath}:${method}`
 }
-
-module.exports = TrackingCache

--- a/src/v2/cache.js
+++ b/src/v2/cache.js
@@ -1,0 +1,775 @@
+import { Redis } from 'iovalkey'
+import { randomUUID } from 'node:crypto'
+import { EventEmitter, setMaxListeners } from 'node:events'
+import { Writable } from 'node:stream'
+import { setTimeout as sleep } from 'node:timers/promises'
+import pMap from 'p-map'
+import xxhash from 'xxhash-wasm'
+import Keys from './keys.js'
+import TrackingCache from './tracking-cache.js'
+import {
+  decodeBody,
+  encodeBodyChunk,
+  normalizePrefix,
+  normalizePrefixes,
+  serializeForHash,
+  serializeHeaders,
+  unique,
+  validateHashTagPart,
+  varyMatches
+} from './utils.js'
+
+const DATA_VERSION = 'v2'
+const DEFAULT_MAX_ENTRY_SIZE = 10 * 1024 * 1024
+const DEFAULT_MAX_BATCH_SIZE = 100
+const DEFAULT_CONCURRENCY = 10
+const { h64ToString } = await xxhash()
+
+export default class RedisCache extends EventEmitter {
+  #client
+  #clientOpts
+  #trackingClient
+  #keyspaceClient
+  #closed = false
+  #subscribed = false
+  #prefix
+  #clusterId
+  #maxEntrySize
+  #maxBatchSize
+  #concurrency
+  #cacheTagsHeader
+  #errorCallback
+  #trackingCache
+  #clientConfigKeyspaceEventNotify
+  #abortController
+
+  constructor (opts = {}) {
+    super()
+
+    if (typeof opts !== 'object') {
+      throw new TypeError('expected opts to be an object')
+    }
+
+    const { keyPrefix, ...clientOpts } = opts.clientOpts ?? {}
+
+    const prefix = validateHashTagPart('prefix', opts.prefix ?? keyPrefix ?? '', true)
+    this.#prefix = normalizePrefix(prefix)
+    this.#clusterId = opts.clusterId === undefined ? undefined : validateHashTagPart('clusterId', opts.clusterId, false)
+    this.#clientOpts = { enableAutoPipelining: true, ...clientOpts }
+    this.#client = new Redis(this.#clientOpts)
+    this.#maxEntrySize = opts.maxEntrySize ?? DEFAULT_MAX_ENTRY_SIZE
+    this.#maxBatchSize = opts.maxBatchSize ?? DEFAULT_MAX_BATCH_SIZE
+    this.#concurrency = opts.concurrency ?? DEFAULT_CONCURRENCY
+    this.#cacheTagsHeader = opts.cacheTagsHeader?.toLowerCase()
+    this.#clientConfigKeyspaceEventNotify = opts.clientConfigKeyspaceEventNotify ?? true
+    this.#errorCallback = opts.errorCallback ?? ((err) => console.error('Unhandled error in RedisCache:', err))
+    this.#abortController = new AbortController()
+    setMaxListeners(100, this.#abortController.signal)
+
+    if (opts.tracking !== false) {
+      this.#trackingCache = new TrackingCache({ maxSize: opts.maxSize, maxCount: opts.maxCount })
+      if (opts.clientConfigTracking !== false) {
+        this.#subscribeTracking().catch(err => this.#errorCallback(err))
+      }
+    }
+  }
+
+  get version () {
+    return '2.0.0'
+  }
+
+  get dataVersion () {
+    return DATA_VERSION
+  }
+
+  get prefix () {
+    return this.#prefix
+  }
+
+  get clusterId () {
+    return this.#clusterId
+  }
+
+  get client () {
+    return this.#client
+  }
+
+  async get (key, prefixes, includeBody = true) {
+    if (this.#closed) {
+      return undefined
+    }
+
+    for (const prefix of normalizePrefixes(this.#prefix, prefixes)) {
+      const tracked = this.#trackingCache?.get(prefix, key)
+      if (tracked) {
+        if (includeBody === false) {
+          const { body, ...metadata } = tracked
+          return metadata
+        }
+        return tracked
+      }
+
+      const hashes = await this.#hashKey(key)
+      const keys = new Keys(prefix, this.#clusterId)
+      const resourceKey = keys.resource(hashes.resourceHash)
+      const ids = await this.#getLiveIds(resourceKey)
+      if (ids.length === 0) {
+        continue
+      }
+
+      const entries = await this.#getEntriesByIds(prefix, ids)
+      const headers = serializeHeaders(key.headers)
+      let selected
+
+      for (const entry of entries) {
+        if (!varyMatches(entry, headers)) {
+          continue
+        }
+        if (!selected || entry.specificity > selected.specificity) {
+          selected = entry
+        }
+      }
+
+      if (!selected) {
+        continue
+      }
+
+      let body
+      if (includeBody !== false) {
+        const rawBody = await this.#client.get(keys.body(selected.id))
+        if (rawBody === null) {
+          await this.#deleteEntry(prefix, selected)
+          continue
+        }
+        body = decodeBody(rawBody)
+      }
+
+      const value = this.#buildValue(selected, body)
+      if (includeBody !== false) {
+        this.#trackingCache?.set(prefix, selected, value)
+      }
+      return value
+    }
+  }
+
+  async getKeys (keys, prefixes) {
+    const results = []
+    await this.#mapLimit(Array.from(keys), async key => {
+      const result = await this.get(key, prefixes)
+      if (result) {
+        results.push(result)
+      }
+    })
+    return results
+  }
+
+  createWriteStream (key, value) {
+    let size = 0
+    let body = ''
+    let aborted = false
+    const maxEntrySize = this.#maxEntrySize
+    const errorCallback = this.#errorCallback
+    const store = this
+
+    return new Writable({
+      write (chunk, encoding, callback) {
+        const encoded = encodeBodyChunk(chunk, encoding)
+        size += encoded.length
+
+        if (size >= maxEntrySize) {
+          aborted = true
+          callback()
+          return
+        }
+
+        body += body ? ` ${encoded}` : encoded
+        callback()
+      },
+      final (callback) {
+        if (aborted) {
+          callback()
+          return
+        }
+
+        store.#set(key, value, body)
+          .then(() => callback())
+          /* node:coverage ignore next 4 */
+          /* c8 ignore next 4 */
+          .catch(err => {
+            errorCallback(err)
+            callback(err)
+          })
+      }
+    })
+  }
+
+  async delete (key, prefixes) {
+    if (this.#closed) {
+      return
+    }
+
+    for (const prefix of normalizePrefixes(this.#prefix, prefixes)) {
+      const hashes = await this.#hashKey(key)
+      const keys = new Keys(prefix, this.#clusterId)
+      await this.#deleteByIndex(prefix, keys.originPath(hashes.originPathHash))
+    }
+  }
+
+  async deleteKeys (inputKeys, prefixes) {
+    if (this.#closed) {
+      return
+    }
+
+    for (const prefix of normalizePrefixes(this.#prefix, prefixes)) {
+      await this.#mapLimit(Array.from(inputKeys), async key => {
+        if (key.id) {
+          await this.#deleteId(prefix, key.id)
+          return
+        }
+
+        const hashes = await this.#hashKey(key)
+        const keys = new Keys(prefix, this.#clusterId)
+        await this.#deleteByIndex(prefix, keys.resourceIndex(hashes.resourceHash))
+      })
+    }
+  }
+
+  async deleteIds (ids, prefixes) {
+    if (this.#closed) {
+      return
+    }
+
+    for (const prefix of normalizePrefixes(this.#prefix, prefixes)) {
+      await this.#mapLimit(ids, id => this.#deleteId(prefix, id))
+    }
+  }
+
+  async deleteTag (tags, prefixes) {
+    if (!Array.isArray(tags)) {
+      tags = [tags]
+    }
+
+    tags = unique(tags).filter(Boolean).sort()
+    if (tags.length === 0) {
+      return
+    }
+
+    for (const prefix of normalizePrefixes(this.#prefix, prefixes)) {
+      const keys = new Keys(prefix, this.#clusterId)
+      const tagHashes = await this.#getTagHashes(tags)
+      const ids = await this.#getLiveIds(keys.tag(tagHashes[0]))
+      const entries = await this.#getEntriesByIds(prefix, ids)
+      const matching = entries.filter(entry => this.#shouldMatchAllTags(entry, tags))
+      await this.#mapLimit(matching, entry => this.#deleteEntry(prefix, entry))
+
+      for (const tag of tags) {
+        this.emit('tag:delete', { tag, prefix })
+      }
+    }
+  }
+
+  async deleteTags (tags, prefixes) {
+    await this.#mapLimit(tags, tag => this.deleteTag(tag, prefixes))
+  }
+
+  async entries (filter = {}, prefixes) {
+    const results = []
+
+    for (const prefix of normalizePrefixes(this.#prefix, prefixes)) {
+      if (filter.id) {
+        const entry = await this.#getEntryById(prefix, filter.id)
+        if (entry) {
+          results.push(this.#buildEntryResult(entry))
+        }
+        continue
+      }
+
+      const indexKey = await this.#getIndexKey(prefix, filter)
+      const ids = await this.#getLiveIds(indexKey)
+      const entries = await this.#getEntriesByIds(prefix, ids)
+      results.push(...entries.map(entry => this.#buildEntryResult(entry)))
+    }
+
+    return results
+  }
+
+  async deleteEntries (filter = {}, prefixes) {
+    const deleted = []
+
+    for (const prefix of normalizePrefixes(this.#prefix, prefixes)) {
+      if (filter.id) {
+        const entry = await this.#getEntryById(prefix, filter.id)
+        if (entry) {
+          await this.#deleteEntry(prefix, entry)
+          deleted.push(this.#buildEntryResult(entry))
+        }
+        continue
+      }
+
+      const indexKey = await this.#getIndexKey(prefix, filter)
+      const ids = await this.#getLiveIds(indexKey)
+      const entries = await this.#getEntriesByIds(prefix, ids)
+      await this.#mapLimit(entries, async entry => {
+        await this.#deleteEntry(prefix, entry)
+        deleted.push(this.#buildEntryResult(entry))
+      })
+    }
+
+    return deleted
+  }
+
+  async getTag (tag, prefixes) {
+    const results = []
+    const tagHash = await this.#hash(tag)
+
+    for (const prefix of normalizePrefixes(this.#prefix, prefixes)) {
+      const keys = new Keys(prefix, this.#clusterId)
+      const ids = await this.#getLiveIds(keys.tag(tagHash))
+      const entries = await this.#getEntriesByIds(prefix, ids)
+      results.push(...entries.map(entry => this.#buildEntryResult(entry)))
+    }
+
+    return results
+  }
+
+  async getTags (tags, prefixes) {
+    const results = []
+    await this.#mapLimit(unique(tags.flat()), async tag => {
+      results.push(...await this.getTag(tag, prefixes))
+    })
+    return results
+  }
+
+  async getDependentEntries (id, prefixes) {
+    const results = new Map()
+
+    for (const prefix of normalizePrefixes(this.#prefix, prefixes)) {
+      const source = await this.#getEntryById(prefix, id)
+      if (!source || source.tags.length === 0) {
+        continue
+      }
+
+      for (const tag of source.tags) {
+        const entries = await this.getTag(tag, prefix)
+        for (const entry of entries) {
+          if (entry.id !== id && this.#shouldMatchAllTags(entry, source.tags)) {
+            results.set(`${entry.prefix}:${entry.id}`, entry)
+          }
+        }
+      }
+    }
+
+    return Array.from(results.values())
+  }
+
+  async getResponseById (id, prefixes) {
+    for (const prefix of normalizePrefixes(this.#prefix, prefixes)) {
+      const keys = new Keys(prefix, this.#clusterId)
+      const entry = await this.#getEntryById(prefix, id)
+      if (!entry) {
+        continue
+      }
+
+      const rawBody = await this.#client.get(keys.body(id))
+      if (rawBody === null) {
+        continue
+      }
+
+      return decodeBody(rawBody).map(chunk => chunk.toString()).join('')
+    }
+
+    return null
+  }
+
+  async streamEntries (callback, prefixes) {
+    for (const entry of await this.entries({}, prefixes)) {
+      await callback(entry)
+    }
+  }
+
+  async subscribe (prefixes) {
+    if (this.#closed || this.#subscribed) {
+      return
+    }
+    this.#subscribed = true
+
+    const db = this.#clientOpts.db ?? 0
+    const channels = {
+      set: `__keyevent@${db}__:set`,
+      del: `__keyevent@${db}__:del`,
+      expired: `__keyevent@${db}__:expired`
+    }
+    const normalizedPrefixes = new Set(normalizePrefixes(this.#prefix, prefixes))
+
+    try {
+      this.#keyspaceClient = new Redis({ ...this.#clientOpts, enableAutoPipelining: false })
+
+      if (this.#clientConfigKeyspaceEventNotify) {
+        await this.#keyspaceClient.config('SET', 'notify-keyspace-events', 'AKE')
+      }
+
+      this.#keyspaceClient.on('message', async (channel, key) => {
+        try {
+          let matchedPrefix
+          let entryPrefix
+
+          for (const prefix of normalizedPrefixes) {
+            const currentEntryPrefix = new Keys(prefix, this.#clusterId).entry('')
+            if (key.startsWith(currentEntryPrefix)) {
+              matchedPrefix = prefix
+              entryPrefix = currentEntryPrefix
+              break
+            }
+          }
+
+          const prefix = matchedPrefix
+          if (prefix === undefined) {
+            return
+          }
+
+          const id = key.slice(entryPrefix.length)
+          if (channel === channels.set) {
+            const entry = await this.#getEntryById(prefix, id)
+            if (!entry) {
+              return
+            }
+            this.emit('subscription:entry:add', { prefix, id, metadata: entry, value: this.#buildValue(entry) })
+          } else if (channel === channels.del || channel === channels.expired) {
+            this.emit('subscription:entry:delete', { prefix, id })
+          }
+        } catch (err) {
+          this.#errorCallback(err)
+        }
+      })
+
+      await this.#keyspaceClient.subscribe(channels.set, channels.del, channels.expired)
+      /* node:coverage ignore next 7 */
+      /* c8 ignore next 6 */
+    } catch (err) {
+      this.#subscribed = false
+      await this.#keyspaceClient?.quit()
+      this.#keyspaceClient = undefined
+      throw err
+    }
+  }
+
+  async close () {
+    if (this.#closed) {
+      return
+    }
+    this.#closed = true
+    this.#abortController.abort()
+    await sleep(100)
+
+    const promises = [this.#client.quit()]
+    if (this.#trackingClient) {
+      promises.push(this.#trackingClient.quit())
+    }
+
+    if (this.#keyspaceClient) {
+      promises.push(this.#keyspaceClient.quit())
+    }
+    await Promise.all(promises)
+  }
+
+  async #set (key, value, body) {
+    if (this.#closed) {
+      return
+    }
+
+    const cacheKey = { ...key, id: key.id ?? randomUUID() }
+    const prefix = this.#prefix
+    const keys = new Keys(prefix, this.#clusterId)
+    const hashes = await this.#hashKey(cacheKey)
+    const vary = serializeHeaders(value.vary)
+    const varyHash = await this.#hash(serializeForHash(vary))
+    let tags = []
+
+    if (this.#cacheTagsHeader) {
+      for (const [name, headerValue] of Object.entries(value.headers ?? {})) {
+        if (name.toLowerCase() !== this.#cacheTagsHeader) {
+          continue
+        }
+
+        tags = unique((Array.isArray(headerValue) ? headerValue.join(',') : headerValue).split(',').map(tag => tag.trim()).filter(Boolean)).sort()
+        break
+      }
+    }
+
+    const tagHashes = await this.#getTagHashes(tags)
+    const deleteAt = Math.floor(value.deleteAt / 1000)
+    const resourceKey = keys.resource(hashes.resourceHash)
+
+    await this.#cleanupIndex(resourceKey)
+    const existingEntries = await this.#getEntriesByIds(prefix, await this.#getLiveIds(resourceKey))
+    const duplicate = existingEntries.find(entry => entry.varyHash === varyHash)
+    if (duplicate) {
+      await this.#deleteEntry(prefix, duplicate)
+    }
+
+    const entry = {
+      id: cacheKey.id,
+      prefix,
+      origin: cacheKey.origin,
+      method: cacheKey.method,
+      path: cacheKey.path,
+      originHash: hashes.originHash,
+      originMethodHash: hashes.originMethodHash,
+      originPathHash: hashes.originPathHash,
+      resourceHash: hashes.resourceHash,
+      varyHash,
+      vary,
+      specificity: Object.keys(vary).length,
+      tags,
+      tagHashes,
+      statusCode: value.statusCode,
+      statusMessage: value.statusMessage,
+      headers: value.headers,
+      cachedAt: value.cachedAt,
+      staleAt: value.staleAt,
+      deleteAt: value.deleteAt,
+      cacheControlDirectives: value.cacheControlDirectives
+    }
+
+    if (value.headers?.etag) {
+      entry.etag = value.headers.etag
+    }
+
+    const indexKeys = this.#getEntryIndexKeys(keys, entry)
+    const pipeline = this.#client.pipeline()
+    pipeline.set(keys.entry(entry.id), JSON.stringify(entry), 'EXAT', deleteAt)
+    pipeline.set(keys.body(entry.id), body, 'EXAT', deleteAt)
+
+    for (const indexKey of indexKeys) {
+      pipeline.zadd(indexKey, deleteAt, entry.id)
+      pipeline.expireat(indexKey, deleteAt, 'NX')
+      pipeline.expireat(indexKey, deleteAt, 'GT')
+    }
+
+    await pipeline.exec()
+    this.emit('entry:write', { prefix, id: entry.id, metadata: entry, value })
+  }
+
+  async #subscribeTracking () {
+    this.#trackingClient ??= new Redis({ ...this.#clientOpts, enableAutoPipelining: false })
+    const clientId = await this.#trackingClient.client('ID')
+    await this.#client.client('TRACKING', 'ON', 'REDIRECT', clientId)
+    await this.#trackingClient.subscribe('__redis__:invalidate')
+
+    this.#trackingClient.on('message', (_channel, key) => {
+      if (!key || !key.includes('data:v2:resource:')) {
+        return
+      }
+
+      // Redis invalidations are key based. Deleting the whole resource bucket is safe.
+      this.#trackingCache = new TrackingCache()
+    })
+  }
+
+  #buildValue (entry, body) {
+    const value = {
+      statusCode: entry.statusCode,
+      statusMessage: entry.statusMessage,
+      headers: entry.headers,
+      cachedAt: entry.cachedAt,
+      staleAt: entry.staleAt,
+      deleteAt: entry.deleteAt,
+      cacheControlDirectives: entry.cacheControlDirectives,
+      body
+    }
+
+    if (entry.etag) {
+      value.etag = entry.etag
+    }
+
+    if (entry.vary && Object.keys(entry.vary).length > 0) {
+      value.vary = entry.vary
+    }
+
+    return value
+  }
+
+  #buildEntryResult (entry) {
+    return {
+      id: entry.id,
+      prefix: entry.prefix,
+      origin: entry.origin,
+      method: entry.method,
+      path: entry.path,
+      tags: entry.tags,
+      cacheTags: entry.tags,
+      statusCode: entry.statusCode,
+      statusMessage: entry.statusMessage,
+      headers: entry.headers,
+      cachedAt: entry.cachedAt,
+      staleAt: entry.staleAt,
+      deleteAt: entry.deleteAt,
+      cacheControlDirectives: entry.cacheControlDirectives
+    }
+  }
+
+  #getEntryFromValue (value) {
+    if (!value) {
+      return
+    }
+
+    return JSON.parse(value)
+  }
+
+  #shouldMatchAllTags (entry, tags) {
+    for (const tag of tags) {
+      if (!entry.tags.includes(tag)) {
+        return false
+      }
+    }
+
+    return true
+  }
+
+  async #hashKey (key) {
+    const originHash = await this.#hash(key.origin)
+    const originMethodHash = await this.#hash(serializeForHash([key.origin, key.method]))
+    const originPathHash = await this.#hash(serializeForHash([key.origin, key.path]))
+    const resourceHash = await this.#hash(serializeForHash([key.origin, key.method, key.path]))
+
+    return { originHash, originMethodHash, originPathHash, resourceHash }
+  }
+
+  async #hash (value) {
+    return h64ToString(value)
+  }
+
+  async #getLiveIds (indexKey) {
+    const now = Math.floor(Date.now() / 1000)
+    await this.#cleanupIndex(indexKey, now)
+    return this.#client.zrangebyscore(indexKey, `(${now}`, '+inf')
+  }
+
+  async #cleanupIndex (indexKey, now = Math.floor(Date.now() / 1000)) {
+    await this.#client.zremrangebyscore(indexKey, '-inf', now)
+  }
+
+  async #getEntriesByIds (prefix, ids) {
+    if (ids.length === 0) {
+      return []
+    }
+
+    const keys = new Keys(prefix, this.#clusterId)
+    const values = await this.#client.mget(...ids.map(id => keys.entry(id)))
+    const entries = []
+    const now = Date.now()
+
+    for (const value of values) {
+      const entry = this.#getEntryFromValue(value)
+      if (!entry || entry.deleteAt <= now) {
+        continue
+      }
+
+      entries.push(entry)
+    }
+
+    return entries
+  }
+
+  async #getEntryById (prefix, id) {
+    const keys = new Keys(prefix, this.#clusterId)
+    const entry = this.#getEntryFromValue(await this.#client.get(keys.entry(id)))
+    if (!entry || entry.deleteAt <= Date.now()) {
+      return
+    }
+
+    return entry
+  }
+
+  async #deleteByIndex (prefix, indexKey) {
+    const ids = await this.#getLiveIds(indexKey)
+    const entries = await this.#getEntriesByIds(prefix, ids)
+    await this.#mapLimit(entries, entry => this.#deleteEntry(prefix, entry))
+  }
+
+  async #deleteId (prefix, id) {
+    const entry = await this.#getEntryById(prefix, id)
+    if (!entry) {
+      return
+    }
+
+    await this.#deleteEntry(prefix, entry)
+  }
+
+  async #deleteEntry (prefix, entry) {
+    const keys = new Keys(prefix, this.#clusterId)
+    const pipeline = this.#client.pipeline()
+
+    pipeline.del(keys.entry(entry.id))
+    pipeline.del(keys.body(entry.id))
+    for (const indexKey of this.#getEntryIndexKeys(keys, entry)) {
+      pipeline.zrem(indexKey, entry.id)
+    }
+
+    await pipeline.exec()
+    this.#trackingCache?.deleteEntry(prefix, entry)
+    this.emit('entry:delete', { id: entry.id, prefix })
+  }
+
+  #getEntryIndexKeys (keys, entry) {
+    const indexKeys = [
+      keys.all(),
+      keys.origin(entry.originHash),
+      keys.originMethod(entry.originMethodHash),
+      keys.originPath(entry.originPathHash),
+      keys.resourceIndex(entry.resourceHash),
+      keys.resource(entry.resourceHash)
+    ]
+
+    for (const tagHash of entry.tagHashes ?? []) {
+      indexKeys.push(keys.tag(tagHash))
+    }
+
+    return indexKeys
+  }
+
+  async #getIndexKey (prefix, filter) {
+    const keys = new Keys(prefix, this.#clusterId)
+    if (!filter.origin) {
+      return keys.all()
+    }
+
+    const hashes = await this.#hashKey({
+      origin: filter.origin,
+      method: filter.method ?? '',
+      path: filter.path ?? ''
+    })
+
+    if (filter.method && filter.path) {
+      return keys.resourceIndex(hashes.resourceHash)
+    }
+
+    if (filter.method) {
+      return keys.originMethod(hashes.originMethodHash)
+    }
+
+    if (filter.path) {
+      return keys.originPath(hashes.originPathHash)
+    }
+
+    return keys.origin(hashes.originHash)
+  }
+
+  async #getTagHashes (tags) {
+    const hashes = new Array(tags.length)
+    for (let i = 0; i < tags.length; i++) {
+      hashes[i] = await this.#hash(tags[i])
+    }
+    return hashes
+  }
+
+  async #mapLimit (items, fn) {
+    return pMap(items, item => {
+      if (this.#abortController.signal.aborted) {
+        return
+      }
+
+      return fn(item)
+    }, { concurrency: this.#concurrency })
+  }
+}

--- a/src/v2/index.d.ts
+++ b/src/v2/index.d.ts
@@ -1,0 +1,94 @@
+import { EventEmitter } from 'node:events'
+import { Writable } from 'node:stream'
+import { RedisOptions } from 'iovalkey'
+import { GetResult, CacheKey, CachedResponse } from '../common/internal-types'
+
+export interface RedisCacheOpts {
+  prefix?: string
+  clusterId?: string
+  clientConfigTracking?: boolean
+  clientConfigKeyspaceEventNotify?: boolean
+  clientOpts?: RedisOptions
+  maxEntrySize?: number
+  maxSize?: number
+  maxCount?: number
+  maxBatchSize?: number
+  concurrency?: number
+  tracking?: boolean
+  cacheTagsHeader?: string
+  errorCallback?: (err: Error) => void
+}
+
+export interface RedisCacheEntry {
+  id: string
+  prefix: string
+  origin: string
+  path: string
+  method: string
+  statusCode: number
+  statusMessage: string
+  headers: Record<string, string | string[]>
+  tags: string[]
+  cacheTags: string[]
+  cachedAt: number
+  staleAt: number
+  deleteAt: number
+  cacheControlDirectives: Record<string, string | string[]>
+}
+
+export interface RedisCacheFilter {
+  id?: string
+  origin?: string
+  method?: string
+  path?: string
+}
+
+export declare class RedisCache extends EventEmitter {
+  constructor(opts?: RedisCacheOpts)
+
+  readonly version: string
+
+  readonly dataVersion: string
+
+  readonly prefix: string
+
+  readonly clusterId?: string
+
+  get(key: CacheKey, prefixes?: string | string[]): Promise<GetResult | undefined>
+
+  get(key: CacheKey, prefixes: string | string[] | undefined, includeBody: false): Promise<CachedResponse | undefined>
+
+  getKeys(keys: Iterable<CacheKey>, prefixes?: string | string[]): Promise<GetResult[]>
+
+  createWriteStream(key: CacheKey, value: CachedResponse): Writable
+
+  delete(key: CacheKey, prefixes?: string | string[]): Promise<void>
+
+  deleteKeys(keys: Iterable<CacheKey>, prefixes?: string | string[]): Promise<void>
+
+  deleteIds(ids: string[], prefixes?: string | string[]): Promise<void>
+
+  deleteTag(tags: string | string[], prefixes?: string | string[]): Promise<void>
+
+  deleteTags(tags: Array<string | string[]>, prefixes?: string | string[]): Promise<void>
+
+  entries(filter?: RedisCacheFilter, prefixes?: string | string[]): Promise<RedisCacheEntry[]>
+
+  deleteEntries(filter?: RedisCacheFilter, prefixes?: string | string[]): Promise<RedisCacheEntry[]>
+
+  getTag(tag: string, prefixes?: string | string[]): Promise<RedisCacheEntry[]>
+
+  getTags(tags: Array<string | string[]>, prefixes?: string | string[]): Promise<RedisCacheEntry[]>
+
+  streamEntries(callback: (entry: RedisCacheEntry) => Promise<unknown> | unknown, prefixes?: string | string[]): Promise<void>
+
+  subscribe(prefixes?: string | string[]): Promise<void>
+
+  getResponseById(id: string, prefixes?: string | string[]): Promise<string | null>
+
+  getDependentEntries(id: string, prefixes?: string | string[]): Promise<RedisCacheEntry[]>
+
+  close(): Promise<void>
+}
+
+export default RedisCache

--- a/src/v2/index.js
+++ b/src/v2/index.js
@@ -1,0 +1,1 @@
+export { default, default as RedisCache } from './cache.js'

--- a/src/v2/keys.js
+++ b/src/v2/keys.js
@@ -1,0 +1,42 @@
+export default class Keys {
+  constructor (prefix, clusterId) {
+    this.prefix = prefix
+    this.base = clusterId ? `${prefix}{${clusterId}}:data:v2:` : `{${prefix}data:v2}:`
+  }
+
+  entry (id) {
+    return `${this.base}entry:${id}`
+  }
+
+  body (id) {
+    return `${this.base}body:${id}`
+  }
+
+  resource (resourceHash) {
+    return `${this.base}resource:${resourceHash}`
+  }
+
+  all () {
+    return `${this.base}index:all`
+  }
+
+  origin (originHash) {
+    return `${this.base}index:origin:${originHash}`
+  }
+
+  originMethod (originMethodHash) {
+    return `${this.base}index:origin-method:${originMethodHash}`
+  }
+
+  originPath (originPathHash) {
+    return `${this.base}index:origin-path:${originPathHash}`
+  }
+
+  resourceIndex (resourceHash) {
+    return `${this.base}index:resource:${resourceHash}`
+  }
+
+  tag (tag) {
+    return `${this.base}tag:${tag}`
+  }
+}

--- a/src/v2/tracking-cache.js
+++ b/src/v2/tracking-cache.js
@@ -1,0 +1,121 @@
+import lruMap from 'lru_map'
+import { serializeHeaders, varyMatches } from './utils.js'
+
+const { LRUMap } = lruMap
+
+export default class TrackingCache {
+  #data
+  #maxCount
+  #maxSize
+  #count = 0
+  #size = 0
+
+  constructor (opts = {}) {
+    this.#maxCount = opts.maxCount ?? Infinity
+    this.#maxSize = opts.maxSize ?? Infinity
+    this.#data = new LRUMap(this.#maxCount + 1)
+  }
+
+  get count () {
+    return this.#count
+  }
+
+  get size () {
+    return this.#size
+  }
+
+  get (prefix, key) {
+    const entries = this.#data.get(serializeKey(prefix, key))
+    if (!entries) {
+      return
+    }
+
+    const headers = serializeHeaders(key.headers)
+    let best
+
+    for (const entry of entries.values()) {
+      if (!varyMatches(entry.metadata, headers)) {
+        continue
+      }
+
+      if (!best || entry.metadata.specificity > best.metadata.specificity) {
+        best = entry
+      }
+    }
+
+    return best?.value
+  }
+
+  set (prefix, metadata, value) {
+    const key = serializeKey(prefix, metadata)
+    let entries = this.#data.get(key)
+    if (!entries) {
+      entries = new Map()
+      this.#data.set(key, entries)
+    }
+
+    const existing = entries.get(metadata.id)
+    if (existing) {
+      this.#count--
+      this.#size -= existing.size
+    }
+
+    let size = 0
+    for (const chunk of value.body ?? []) {
+      size += chunk.length
+    }
+
+    entries.set(metadata.id, { metadata, value, size })
+    this.#count++
+    this.#size += size
+
+    while (this.#count > this.#maxCount || this.#size > this.#maxSize) {
+      const shifted = this.#data.shift()
+      if (!shifted) {
+        return
+      }
+      for (const entry of shifted[1].values()) {
+        this.#count--
+        this.#size -= entry.size
+      }
+    }
+  }
+
+  delete (prefix, key) {
+    const entries = this.#data.get(serializeKey(prefix, key))
+    if (!entries) {
+      return
+    }
+
+    for (const entry of entries.values()) {
+      this.#count--
+      this.#size -= entry.size
+    }
+    this.#data.delete(serializeKey(prefix, key))
+  }
+
+  deleteEntry (prefix, metadata) {
+    const key = serializeKey(prefix, metadata)
+    const entries = this.#data.get(key)
+    if (!entries) {
+      return
+    }
+
+    const existing = entries.get(metadata.id)
+    if (!existing) {
+      return
+    }
+
+    entries.delete(metadata.id)
+    this.#count--
+    this.#size -= existing.size
+
+    if (entries.size === 0) {
+      this.#data.delete(key)
+    }
+  }
+}
+
+function serializeKey (prefix, key) {
+  return `${prefix}${key.origin}\0${key.method}\0${key.path}`
+}

--- a/src/v2/utils.js
+++ b/src/v2/utils.js
@@ -1,0 +1,89 @@
+export function serializeHeaders (headers) {
+  const entries = Object.entries(headers ?? {})
+    .map(([name, value]) => {
+      if (Array.isArray(value)) {
+        value = value.join(', ')
+      }
+
+      return [name.toLowerCase(), value]
+    })
+    .filter(([, value]) => value !== undefined && value !== '')
+    .sort(([a], [b]) => a.localeCompare(b))
+
+  return Object.fromEntries(entries)
+}
+
+export function serializeForHash (parts) {
+  return JSON.stringify(parts)
+}
+
+export function encodeBodyChunk (chunk, encoding) {
+  return (Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, encoding)).toString('base64')
+}
+
+export function decodeBody (body) {
+  if (!body) {
+    return []
+  }
+  return body.split(' ').filter(Boolean).map(chunk => Buffer.from(chunk, 'base64'))
+}
+
+export function varyMatches (entry, headers) {
+  const vary = entry.vary ?? {}
+
+  for (const [header, value] of Object.entries(vary)) {
+    if ((headers[header] === undefined && value === null) || headers[header] === value) {
+      continue
+    }
+
+    return false
+  }
+
+  return true
+}
+
+export function normalizePrefix (prefix) {
+  if (!prefix) {
+    return ''
+  }
+  return prefix.endsWith(':') ? prefix : `${prefix}:`
+}
+
+export function validateHashTagPart (name, value, allowEmpty) {
+  if (value === undefined || value === null) {
+    if (allowEmpty) {
+      return ''
+    }
+    throw new TypeError(`${name} must be a non-empty string`)
+  }
+
+  if (typeof value !== 'string') {
+    throw new TypeError(`${name} must be a string`)
+  }
+
+  if (!allowEmpty && value.length === 0) {
+    throw new TypeError(`${name} must be a non-empty string`)
+  }
+
+  if (value.includes('{') || value.includes('}')) {
+    throw new TypeError(`${name} cannot contain "{" or "}"`)
+  }
+
+  return value
+}
+
+export function normalizePrefixes (prefix, prefixes) {
+  if (prefixes === undefined) {
+    return [prefix]
+  }
+
+  if (!Array.isArray(prefixes)) {
+    return [normalizePrefix(prefixes)]
+  }
+
+  return prefixes.map(normalizePrefix)
+}
+
+export function unique (values) {
+  return Array.from(new Set(values))
+}

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,18 +1,16 @@
-'use strict'
-
-const { once } = require('node:events')
-const { createGzip, createGunzip } = require('node:zlib')
-const { Redis } = require('iovalkey')
+import { once } from 'node:events'
+import { createGzip, createGunzip } from 'node:zlib'
+import { Redis } from 'iovalkey'
 
 const REDIS_CONNECTION_STRING = 'redis://localhost:6379'
 
-async function cleanValkey () {
+export async function cleanValkey () {
   const redis = new Redis(REDIS_CONNECTION_STRING)
   await redis.flushall()
   redis.quit()
 }
 
-async function getAllKeys () {
+export async function getAllKeys () {
   const redis = new Redis(REDIS_CONNECTION_STRING)
   const keys = await redis.keys('*')
   redis.quit()
@@ -20,7 +18,7 @@ async function getAllKeys () {
   return keys
 }
 
-async function gzip (data) {
+export async function gzip (data) {
   const gzippedData = []
   const stream = createGzip()
 
@@ -34,7 +32,7 @@ async function gzip (data) {
   return Buffer.concat(gzippedData)
 }
 
-async function ungzip (data) {
+export async function ungzip (data) {
   const ungzippedData = []
   const stream = createGunzip()
 
@@ -46,11 +44,4 @@ async function ungzip (data) {
   await once(stream, 'end')
 
   return Buffer.concat(ungzippedData)
-}
-
-module.exports = {
-  cleanValkey,
-  getAllKeys,
-  gzip,
-  ungzip
 }

--- a/test/v1/cache-manager.test.js
+++ b/test/v1/cache-manager.test.js
@@ -1,14 +1,12 @@
-'use strict'
-
-const assert = require('node:assert/strict')
-const { test } = require('node:test')
-const { once } = require('node:events')
-const { randomUUID } = require('node:crypto')
-const { setTimeout: sleep } = require('node:timers/promises')
-const { createServer } = require('node:http')
-const { Client, interceptors } = require('undici')
-const { RedisCacheManager, RedisCacheStore } = require('../index.js')
-const { cleanValkey } = require('./helper.js')
+import assert from 'node:assert/strict'
+import { randomUUID } from 'node:crypto'
+import { once } from 'node:events'
+import { createServer } from 'node:http'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { test } from 'node:test'
+import { Client, interceptors } from 'undici'
+import { RedisCacheManager, RedisCacheStore } from '../../index.js'
+import { cleanValkey } from '../helper.js'
 
 test('cache manager works when notify-keyspace-events is configured on the server', async (t) => {
   await cleanValkey()

--- a/test/v1/example-server.test.js
+++ b/test/v1/example-server.test.js
@@ -1,9 +1,7 @@
-'use strict'
-
-const assert = require('node:assert/strict')
-const { test } = require('node:test')
-const { setTimeout: sleep } = require('node:timers/promises')
-const { spawn } = require('node:child_process')
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { test } from 'node:test'
 
 async function waitForServer (url, maxAttempts = 30) {
   for (let i = 0; i < maxAttempts; i++) {

--- a/test/v1/get-dependent-entries.test.js
+++ b/test/v1/get-dependent-entries.test.js
@@ -1,13 +1,11 @@
-'use strict'
-
-const assert = require('node:assert/strict')
-const { test } = require('node:test')
-const { setTimeout: sleep } = require('node:timers/promises')
-const { createServer } = require('node:http')
-const { once } = require('node:events')
-const { Client, interceptors } = require('undici')
-const { RedisCacheStore, RedisCacheManager } = require('../index.js')
-const { cleanValkey } = require('./helper.js')
+import assert from 'node:assert/strict'
+import { once } from 'node:events'
+import { createServer } from 'node:http'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { test } from 'node:test'
+import { Client, interceptors } from 'undici'
+import { RedisCacheManager, RedisCacheStore } from '../../index.js'
+import { cleanValkey } from '../helper.js'
 
 test('should stream cache entries', async (t) => {
   await cleanValkey()
@@ -89,10 +87,9 @@ test('should stream cache entries', async (t) => {
       })
       assert.strictEqual(statusCode, 200)
     }
-
     {
       const { statusCode } = await client.request({
-        origin, method: 'GET', path: '/bov', headers: { 'cache-tags': 'tag3,tag1,tag7' }
+        origin, method: 'GET', path: '/boz', headers: { 'cache-tags': 'tag3,tag1,tag7' }
       })
       assert.strictEqual(statusCode, 200)
     }
@@ -104,19 +101,41 @@ test('should stream cache entries', async (t) => {
   await sleep(1000)
 
   // Getting all request from the manager
-  const manager = new RedisCacheManager({ configureKeyspaceEventNotification: true })
+  const manager = new RedisCacheManager()
   await manager.subscribe()
   t.after(() => manager.close())
 
-  await store1.deleteTags([['tag1', 'tag2']])
+  const allEntries = []
+  await manager.streamEntries(entry => allEntries.push(entry), '*')
+  assert.strictEqual(allEntries.length, 6)
 
-  const foundEntries = []
-  await manager.streamEntries(entry => foundEntries.push(entry), '*')
-  assert.strictEqual(foundEntries.length, 2)
+  const entry = allEntries.find(entry => entry.path === '/foo')
+  assert.strictEqual(entry.headers['cache-tags'], 'tag1,tag2')
 
-  const entriesCacheTags = foundEntries.map(entry => entry.headers['cache-tags'])
-  assert.deepStrictEqual(entriesCacheTags.sort(), [
-    'tag1,tag3,tag5',
-    'tag3,tag1,tag7'
-  ].sort())
+  const dependentEntries = await manager.getDependentEntries(entry.id, entry.keyPrefix)
+  assert.strictEqual(dependentEntries.length, 3)
+
+  {
+    const entry = dependentEntries.find(entry => entry.path === '/bar')
+    const expectedEntry = allEntries.find(entry => entry.path === '/bar')
+    assert.ok(entry)
+    assert.deepStrictEqual(entry, expectedEntry)
+    assert.deepStrictEqual(entry.cacheTags, ['tag1', 'tag2', 'tag4'])
+  }
+
+  {
+    const entry = dependentEntries.find(entry => entry.path === '/baz')
+    const expectedEntry = allEntries.find(entry => entry.path === '/baz')
+    assert.ok(entry)
+    assert.deepStrictEqual(entry, expectedEntry)
+    assert.deepStrictEqual(entry.cacheTags, ['tag1', 'tag2'])
+  }
+
+  {
+    const entry = dependentEntries.find(entry => entry.path === '/boa')
+    const expectedEntry = allEntries.find(entry => entry.path === '/boa')
+    assert.ok(entry)
+    assert.deepStrictEqual(entry, expectedEntry)
+    assert.deepStrictEqual(entry.cacheTags, ['tag1', 'tag2', 'tag6'])
+  }
 })

--- a/test/v1/global-invalidation.test.js
+++ b/test/v1/global-invalidation.test.js
@@ -1,13 +1,11 @@
-'use strict'
-
-const assert = require('node:assert/strict')
-const { test } = require('node:test')
-const { setTimeout: sleep } = require('node:timers/promises')
-const { createServer } = require('node:http')
-const { once } = require('node:events')
-const { Client, interceptors } = require('undici')
-const { RedisCacheStore, RedisCacheManager } = require('../index.js')
-const { cleanValkey } = require('./helper.js')
+import assert from 'node:assert/strict'
+import { once } from 'node:events'
+import { createServer } from 'node:http'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { test } from 'node:test'
+import { Client, interceptors } from 'undici'
+import { RedisCacheManager, RedisCacheStore } from '../../index.js'
+import { cleanValkey } from '../helper.js'
 
 test('should stream cache entries', async (t) => {
   await cleanValkey()
@@ -89,9 +87,10 @@ test('should stream cache entries', async (t) => {
       })
       assert.strictEqual(statusCode, 200)
     }
+
     {
       const { statusCode } = await client.request({
-        origin, method: 'GET', path: '/boz', headers: { 'cache-tags': 'tag3,tag1,tag7' }
+        origin, method: 'GET', path: '/bov', headers: { 'cache-tags': 'tag3,tag1,tag7' }
       })
       assert.strictEqual(statusCode, 200)
     }
@@ -103,41 +102,19 @@ test('should stream cache entries', async (t) => {
   await sleep(1000)
 
   // Getting all request from the manager
-  const manager = new RedisCacheManager()
+  const manager = new RedisCacheManager({ configureKeyspaceEventNotification: true })
   await manager.subscribe()
   t.after(() => manager.close())
 
-  const allEntries = []
-  await manager.streamEntries(entry => allEntries.push(entry), '*')
-  assert.strictEqual(allEntries.length, 6)
+  await store1.deleteTags([['tag1', 'tag2']])
 
-  const entry = allEntries.find(entry => entry.path === '/foo')
-  assert.strictEqual(entry.headers['cache-tags'], 'tag1,tag2')
+  const foundEntries = []
+  await manager.streamEntries(entry => foundEntries.push(entry), '*')
+  assert.strictEqual(foundEntries.length, 2)
 
-  const dependentEntries = await manager.getDependentEntries(entry.id, entry.keyPrefix)
-  assert.strictEqual(dependentEntries.length, 3)
-
-  {
-    const entry = dependentEntries.find(entry => entry.path === '/bar')
-    const expectedEntry = allEntries.find(entry => entry.path === '/bar')
-    assert.ok(entry)
-    assert.deepStrictEqual(entry, expectedEntry)
-    assert.deepStrictEqual(entry.cacheTags, ['tag1', 'tag2', 'tag4'])
-  }
-
-  {
-    const entry = dependentEntries.find(entry => entry.path === '/baz')
-    const expectedEntry = allEntries.find(entry => entry.path === '/baz')
-    assert.ok(entry)
-    assert.deepStrictEqual(entry, expectedEntry)
-    assert.deepStrictEqual(entry.cacheTags, ['tag1', 'tag2'])
-  }
-
-  {
-    const entry = dependentEntries.find(entry => entry.path === '/boa')
-    const expectedEntry = allEntries.find(entry => entry.path === '/boa')
-    assert.ok(entry)
-    assert.deepStrictEqual(entry, expectedEntry)
-    assert.deepStrictEqual(entry.cacheTags, ['tag1', 'tag2', 'tag6'])
-  }
+  const entriesCacheTags = foundEntries.map(entry => entry.headers['cache-tags'])
+  assert.deepStrictEqual(entriesCacheTags.sort(), [
+    'tag1,tag3,tag5',
+    'tag3,tag1,tag7'
+  ].sort())
 })

--- a/test/v1/interceptor.test.js
+++ b/test/v1/interceptor.test.js
@@ -1,13 +1,11 @@
-'use strict'
-
-const assert = require('node:assert/strict')
-const { test } = require('node:test')
-const { setTimeout: sleep } = require('node:timers/promises')
-const { createServer } = require('node:http')
-const { once } = require('node:events')
-const { Client, interceptors } = require('undici')
-const RedisCacheStore = require('../index.js')
-const { cleanValkey, getAllKeys, gzip, ungzip } = require('./helper.js')
+import assert from 'node:assert/strict'
+import { once } from 'node:events'
+import { createServer } from 'node:http'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { test } from 'node:test'
+import { Client, interceptors } from 'undici'
+import { RedisCacheStore } from '../../index.js'
+import { cleanValkey, getAllKeys, gzip, ungzip } from '../helper.js'
 
 test('caches request successfully', async (t) => {
   let requestsToOrigin = 0

--- a/test/v1/proxy-server.test.js
+++ b/test/v1/proxy-server.test.js
@@ -1,9 +1,7 @@
-'use strict'
-
-const assert = require('node:assert/strict')
-const { test } = require('node:test')
-const { setTimeout: sleep } = require('node:timers/promises')
-const { spawn } = require('node:child_process')
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { test } from 'node:test'
 
 async function waitForServer (url, maxAttempts = 30) {
   for (let i = 0; i < maxAttempts; i++) {

--- a/test/v1/redis-cache-store.test.js
+++ b/test/v1/redis-cache-store.test.js
@@ -1,13 +1,11 @@
 // @ts-check
-'use strict'
-
-const { describe, test } = require('node:test')
-const { strictEqual, deepStrictEqual, notEqual, equal, fail, ok } = require('node:assert')
-const { Readable } = require('node:stream')
-const { once } = require('node:events')
-const { RedisCacheStore } = require('../lib/redis-cache-store')
-const { getAllKeys, cleanValkey } = require('./helper.js')
-const { setTimeout: sleep } = require('node:timers/promises')
+import { deepStrictEqual, equal, fail, notEqual, ok, strictEqual } from 'node:assert'
+import { once } from 'node:events'
+import { Readable } from 'node:stream'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { describe, test } from 'node:test'
+import { RedisCacheStore } from '../../src/v1/redis-cache-store.js'
+import { cleanValkey, getAllKeys } from '../helper.js'
 
 cacheStoreTests(RedisCacheStore)
 
@@ -46,7 +44,7 @@ function cacheStoreTests (CacheStore) {
       const requestBody = ['asd', '123']
 
       /**
-       * @type {import('../lib/internal-types.d.ts').CacheStore}
+       * @type {import('../../src/v1/internal-types.d.ts').CacheStore}
        */
       const store = new CacheStore({
         clientOpts: {
@@ -139,7 +137,7 @@ function cacheStoreTests (CacheStore) {
       const requestBody = ['part1', 'part2']
 
       /**
-       * @type {import('../lib/internal-types.d.ts').CacheStore}
+       * @type {import('../../src/v1/internal-types.d.ts').CacheStore}
        */
       const store = new CacheStore({
         clientOpts: {
@@ -272,7 +270,7 @@ function cacheStoreTests (CacheStore) {
       const requestBody = ['part1', 'part2']
 
       /**
-       * @type {import('../lib/internal-types.d.ts').CacheStore}
+       * @type {import('../../src/v1/internal-types.d.ts').CacheStore}
        */
       const store = new CacheStore({
         clientOpts: {
@@ -321,7 +319,7 @@ function cacheStoreTests (CacheStore) {
       const requestBody = ['part1', 'part2']
 
       /**
-       * @type {import('../lib/internal-types.d.ts').CacheStore}
+       * @type {import('../../src/v1/internal-types.d.ts').CacheStore}
        */
       const store = new CacheStore({
         clientOpts: {
@@ -386,7 +384,7 @@ function cacheStoreTests (CacheStore) {
       const requestBody = ['part1', 'part2']
 
       /**
-       * @type {import('../lib/internal-types.d.ts').CacheStore}
+       * @type {import('../../src/v1/internal-types.d.ts').CacheStore}
        */
       const store = new CacheStore({
         clientOpts: {
@@ -818,7 +816,7 @@ function cacheStoreTests (CacheStore) {
     const requestBody = ['asd', '123']
 
     /**
-     * @type {import('../lib/internal-types.d.ts').CacheStore}
+      * @type {import('../../src/v1/internal-types.d.ts').CacheStore}
      */
     const store = new CacheStore({
       clientOpts: {
@@ -859,8 +857,8 @@ function writeResponse (stream, body = []) {
 }
 
 /**
- * @param {import('../lib/internal-types.d.ts').GetResult} result
- * @returns {Promise<import('../lib/internal-types.d.ts').GetResult | { body: Buffer[] }>}
+  * @param {import('../../src/v1/internal-types.d.ts').GetResult} result
+  * @returns {Promise<import('../../src/v1/internal-types.d.ts').GetResult | { body: Buffer[] }>}
  */
 async function readResponse ({ body: src, ...response }) {
   notEqual(response, undefined)

--- a/test/v1/scanByPattern.test.js
+++ b/test/v1/scanByPattern.test.js
@@ -1,9 +1,7 @@
 // @ts-check
-'use strict'
-
-const { test } = require('node:test')
-const { _scanByPattern: scanByPattern } = require('../lib/redis-cache-store.js')
-const { ok, fail, deepStrictEqual, strictEqual } = require('node:assert')
+import { deepStrictEqual, fail, ok, strictEqual } from 'node:assert'
+import { test } from 'node:test'
+import { _scanByPattern as scanByPattern } from '../../src/v1/redis-cache-store.js'
 
 test('scanByPattern calls callback for matching keys and handles errors', async () => {
   // Mock Redis scan behavior

--- a/test/v1/stale.test.js
+++ b/test/v1/stale.test.js
@@ -1,13 +1,11 @@
 // @ts-check
-'use strict'
-
-const { test, beforeEach } = require('node:test')
-const { once } = require('node:events')
-const { setTimeout: sleep } = require('node:timers/promises')
-const { RedisCacheStore } = require('../lib/redis-cache-store')
-const { createServer } = require('node:http')
-const { Client, interceptors } = require('undici')
-const { Redis } = require('iovalkey')
+import { once } from 'node:events'
+import { createServer } from 'node:http'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { beforeEach, test } from 'node:test'
+import { Redis } from 'iovalkey'
+import { Client, interceptors } from 'undici'
+import { RedisCacheStore } from '../../src/v1/redis-cache-store.js'
 
 beforeEach(async (t) => {
   const client = new Redis()

--- a/test/v1/stream-entries.test.js
+++ b/test/v1/stream-entries.test.js
@@ -1,13 +1,11 @@
-'use strict'
-
-const assert = require('node:assert/strict')
-const { test } = require('node:test')
-const { setTimeout: sleep } = require('node:timers/promises')
-const { createServer } = require('node:http')
-const { once } = require('node:events')
-const { Client, interceptors } = require('undici')
-const { RedisCacheStore, RedisCacheManager } = require('../index.js')
-const { cleanValkey } = require('./helper.js')
+import assert from 'node:assert/strict'
+import { once } from 'node:events'
+import { createServer } from 'node:http'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { test } from 'node:test'
+import { Client, interceptors } from 'undici'
+import { RedisCacheManager, RedisCacheStore } from '../../index.js'
+import { cleanValkey } from '../helper.js'
 
 test('should stream cache entries', async (t) => {
   await cleanValkey()

--- a/test/v1/subscribe.test.js
+++ b/test/v1/subscribe.test.js
@@ -1,13 +1,11 @@
-'use strict'
-
-const assert = require('node:assert/strict')
-const { test } = require('node:test')
-const { setTimeout: sleep } = require('node:timers/promises')
-const { createServer } = require('node:http')
-const { once } = require('node:events')
-const { Client, interceptors } = require('undici')
-const { RedisCacheStore, RedisCacheManager } = require('../index.js')
-const { cleanValkey } = require('./helper.js')
+import assert from 'node:assert/strict'
+import { once } from 'node:events'
+import { createServer } from 'node:http'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { test } from 'node:test'
+import { Client, interceptors } from 'undici'
+import { RedisCacheManager, RedisCacheStore } from '../../index.js'
+import { cleanValkey } from '../helper.js'
 
 test('should notify when a new key is added', async (t) => {
   await cleanValkey()

--- a/test/v1/tracking-cache.test.js
+++ b/test/v1/tracking-cache.test.js
@@ -1,8 +1,6 @@
-'use strict'
-
-const { test } = require('node:test')
-const { strictEqual, deepStrictEqual } = require('node:assert')
-const TrackingCache = require('../lib/tracking-cache')
+import { deepStrictEqual, strictEqual } from 'node:assert'
+import { test } from 'node:test'
+import TrackingCache from '../../src/v1/tracking-cache.js'
 
 test('should override cache entries', async () => {
   const cache = new TrackingCache()

--- a/test/v2/cache.test.js
+++ b/test/v2/cache.test.js
@@ -1,0 +1,622 @@
+import { deepStrictEqual, equal, notEqual, ok, throws } from 'node:assert'
+import { once } from 'node:events'
+import { createServer } from 'node:http'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { test } from 'node:test'
+import { Client, interceptors } from 'undici'
+import DefaultCache, { createManager, createStore, RedisCache, RedisCacheManager, RedisCacheStore } from '../../index.js'
+import TrackingCache from '../../src/v2/tracking-cache.js'
+import {
+  decodeBody,
+  encodeBodyChunk,
+  normalizePrefix,
+  normalizePrefixes,
+  serializeForHash,
+  serializeHeaders,
+  unique,
+  validateHashTagPart,
+  varyMatches
+} from '../../src/v2/utils.js'
+import { cleanValkey, getAllKeys } from '../helper.js'
+
+function cacheValue (opts = {}) {
+  return {
+    statusCode: 200,
+    statusMessage: '',
+    headers: opts.headers ?? {},
+    vary: opts.vary,
+    cachedAt: Date.now(),
+    staleAt: Date.now() + 10000,
+    deleteAt: Date.now() + 20000,
+    cacheControlDirectives: {}
+  }
+}
+
+async function write (store, key, value, body) {
+  const stream = store.createWriteStream(key, value)
+  stream.end(body)
+  await once(stream, 'close')
+}
+
+test('v2 stores and reads variants without scan-backed metadata keys', async (t) => {
+  await cleanValkey()
+
+  const store = new RedisCache({
+    prefix: `${crypto.randomUUID()}:`,
+    tracking: false,
+    cacheTagsHeader: 'cache-tag'
+  })
+
+  t.after(() => store.close())
+
+  const key = {
+    origin: 'https://example.com',
+    method: 'GET',
+    path: '/foo',
+    headers: { language: 'en' }
+  }
+
+  const value = {
+    statusCode: 200,
+    statusMessage: '',
+    headers: { 'cache-tag': 'tag1,tag2' },
+    vary: { language: 'en' },
+    cachedAt: Date.now(),
+    staleAt: Date.now() + 10000,
+    deleteAt: Date.now() + 20000,
+    cacheControlDirectives: {}
+  }
+
+  const writeStream = store.createWriteStream(key, value)
+  writeStream.end('hello')
+  await once(writeStream, 'close')
+
+  const result = await store.get({ ...key })
+  notEqual(result, undefined)
+  deepStrictEqual(result.body, [Buffer.from('hello')])
+  equal(result.vary.language, 'en')
+
+  const miss = await store.get({ ...key, headers: { language: 'it' } })
+  equal(miss, undefined)
+
+  const entries = await store.entries({ origin: key.origin, method: key.method, path: key.path })
+  equal(entries.length, 1)
+  deepStrictEqual(entries[0].tags, ['tag1', 'tag2'])
+
+  const keys = await getAllKeys()
+  equal(keys.some(key => key.includes('metadata:')), false)
+  equal(keys.some(key => key.includes('tag1')), false)
+  equal(keys.some(key => key.includes('tag2')), false)
+})
+
+test('v2 is the default public API', async () => {
+  equal(DefaultCache, RedisCache)
+  const store = createStore({ tracking: false })
+  equal(store.constructor, RedisCache)
+  await store.close()
+})
+
+test('versioned factories can still create v1 classes', async () => {
+  const store = createStore({ tracking: false }, '1.0.0')
+  const storeAlias = createStore({ tracking: false }, '1')
+  const manager = createManager({}, '1.0.0')
+  const managerAlias = createManager({}, '1')
+  const v2Manager = createManager({ tracking: false })
+
+  try {
+    equal(store.constructor, RedisCacheStore)
+    equal(storeAlias.constructor, RedisCacheStore)
+    equal(manager.constructor, RedisCacheManager)
+    equal(managerAlias.constructor, RedisCacheManager)
+    equal(v2Manager.constructor, RedisCache)
+  } finally {
+    await store.close()
+    await storeAlias.close()
+    await manager.close()
+    await managerAlias.close()
+    await v2Manager.close()
+  }
+})
+
+test('v2 works with undici cache interceptor', async (t) => {
+  await cleanValkey()
+
+  let requests = 0
+  const server = createServer((req, res) => {
+    requests++
+    res.setHeader('cache-control', 'public, s-maxage=60')
+    res.setHeader('cache-tag', req.headers['cache-tag'] ?? 'default')
+    if (req.headers.language) {
+      res.setHeader('vary', 'language')
+    }
+    res.end(`${req.headers.language ?? 'none'}:${requests}`)
+  }).listen(0)
+  await once(server, 'listening')
+
+  const store = createStore({ prefix: `${crypto.randomUUID()}:`, tracking: false, cacheTagsHeader: 'cache-tag' })
+  const origin = `http://localhost:${server.address().port}`
+  const client = new Client(origin).compose(interceptors.cache({ store }))
+
+  t.after(async () => {
+    server.close()
+    await client.close()
+    await store.close()
+  })
+
+  {
+    const { body } = await client.request({ origin, method: 'GET', path: '/foo', headers: { language: 'en', 'cache-tag': 'tag:raw' } })
+    equal(await body.text(), 'en:1')
+  }
+
+  await sleep(100)
+
+  {
+    const { body } = await client.request({ origin, method: 'GET', path: '/foo', headers: { language: 'en' } })
+    equal(await body.text(), 'en:1')
+  }
+
+  {
+    const { body } = await client.request({ origin, method: 'GET', path: '/foo', headers: { language: 'it' } })
+    equal(await body.text(), 'it:2')
+  }
+
+  await store.deleteTags(['tag:raw'])
+
+  {
+    const { body } = await client.request({ origin, method: 'GET', path: '/foo', headers: { language: 'en' } })
+    equal(await body.text(), 'en:3')
+  }
+})
+
+test('v2 replaces same vary variant and keeps different variants', async (t) => {
+  await cleanValkey()
+
+  const store = new RedisCache({ prefix: `${crypto.randomUUID()}:`, tracking: false })
+  t.after(() => store.close())
+
+  const baseKey = { origin: 'https://example.com', method: 'GET', path: '/foo' }
+  const baseValue = {
+    statusCode: 200,
+    statusMessage: '',
+    headers: {},
+    cachedAt: Date.now(),
+    staleAt: Date.now() + 10000,
+    deleteAt: Date.now() + 20000,
+    cacheControlDirectives: {}
+  }
+
+  {
+    const stream = store.createWriteStream({ ...baseKey, headers: { language: 'en' } }, {
+      ...baseValue,
+      vary: { language: 'en' }
+    })
+    stream.end('en-1')
+    await once(stream, 'close')
+  }
+
+  {
+    const stream = store.createWriteStream({ ...baseKey, headers: { language: 'it' } }, {
+      ...baseValue,
+      vary: { language: 'it' }
+    })
+    stream.end('it')
+    await once(stream, 'close')
+  }
+
+  {
+    const stream = store.createWriteStream({ ...baseKey, headers: { language: 'en' } }, {
+      ...baseValue,
+      vary: { language: 'en' }
+    })
+    stream.end('en-2')
+    await once(stream, 'close')
+  }
+
+  const entries = await store.entries({ origin: baseKey.origin, method: baseKey.method, path: baseKey.path })
+  equal(entries.length, 2)
+
+  const en = await store.get({ ...baseKey, headers: { language: 'en' } })
+  deepStrictEqual(en.body, [Buffer.from('en-2')])
+
+  const it = await store.get({ ...baseKey, headers: { language: 'it' } })
+  deepStrictEqual(it.body, [Buffer.from('it')])
+})
+
+test('v2 selects the most specific matching vary variant', async (t) => {
+  await cleanValkey()
+
+  const store = new RedisCache({ prefix: `${crypto.randomUUID()}:`, tracking: false })
+  t.after(() => store.close())
+
+  const key = { origin: 'https://example.com', method: 'GET', path: '/foo' }
+  const value = cacheValue()
+
+  for (const [headers, vary, body] of [
+    [{}, {}, 'generic'],
+    [{ language: 'en' }, { language: 'en' }, 'language'],
+    [{ language: 'en', device: 'mobile' }, { language: 'en', device: 'mobile' }, 'language-device']
+  ]) {
+    const stream = store.createWriteStream({ ...key, headers }, { ...value, vary })
+    stream.end(body)
+    await once(stream, 'close')
+  }
+
+  const result = await store.get({ ...key, headers: { language: 'en', device: 'mobile' } })
+  deepStrictEqual(result.body, [Buffer.from('language-device')])
+
+  const fallback = await store.get({ ...key, headers: { language: 'en', device: 'desktop' } })
+  deepStrictEqual(fallback.body, [Buffer.from('language')])
+})
+
+test('v2 deletes by origin/path across methods and by combined tags', async (t) => {
+  await cleanValkey()
+
+  const store = new RedisCache({
+    prefix: `${crypto.randomUUID()}:`,
+    tracking: false,
+    cacheTagsHeader: 'cache-tag'
+  })
+  t.after(() => store.close())
+
+  for (const [method, path, tags, body] of [
+    ['GET', '/foo', 'tag1,tag2', 'a'],
+    ['POST', '/foo', 'tag1,tag2,tag3', 'b'],
+    ['GET', '/bar', 'tag1,tag3', 'c']
+  ]) {
+    const stream = store.createWriteStream({ origin: 'https://example.com', method, path }, {
+      statusCode: 200,
+      statusMessage: '',
+      headers: { 'cache-tag': tags },
+      cachedAt: Date.now(),
+      staleAt: Date.now() + 10000,
+      deleteAt: Date.now() + 20000,
+      cacheControlDirectives: {}
+    })
+    stream.end(body)
+    await once(stream, 'close')
+  }
+
+  await store.delete({ origin: 'https://example.com', path: '/foo' })
+  equal((await store.entries({ origin: 'https://example.com' })).length, 1)
+
+  for (const [method, path, tags, body] of [
+    ['GET', '/foo', 'tag1,tag2', 'a'],
+    ['POST', '/foo', 'tag1,tag2,tag3', 'b']
+  ]) {
+    const stream = store.createWriteStream({ origin: 'https://example.com', method, path }, {
+      statusCode: 200,
+      statusMessage: '',
+      headers: { 'cache-tag': tags },
+      cachedAt: Date.now(),
+      staleAt: Date.now() + 10000,
+      deleteAt: Date.now() + 20000,
+      cacheControlDirectives: {}
+    })
+    stream.end(body)
+    await once(stream, 'close')
+  }
+
+  await store.deleteTags([['tag1', 'tag2']])
+  const remaining = await store.entries({ origin: 'https://example.com' })
+  equal(remaining.length, 1)
+  equal(remaining[0].path, '/bar')
+})
+
+test('v2 tracking cache selects variants and evicts entries', () => {
+  const cache = new TrackingCache({ maxCount: 2, maxSize: 4 })
+  const base = { prefix: 'p:', origin: 'https://example.com', method: 'GET', path: '/foo' }
+
+  equal(cache.count, 0)
+  equal(cache.size, 0)
+  equal(cache.get('p:', base), undefined)
+
+  cache.set('p:', { ...base, id: 'a', specificity: 1, vary: { language: 'en' } }, { body: [Buffer.from('aa')] })
+  cache.set('p:', { ...base, id: 'b', specificity: 2, vary: { language: 'en', device: 'm' } }, { body: [Buffer.from('bb')] })
+
+  deepStrictEqual(cache.get('p:', { ...base, headers: { language: 'en', device: 'm' } }).body, [Buffer.from('bb')])
+  deepStrictEqual(cache.get('p:', { ...base, headers: { language: 'en' } }).body, [Buffer.from('aa')])
+  equal(cache.get('p:', { ...base, headers: { language: 'it' } }), undefined)
+
+  cache.set('p:', { ...base, id: 'a', specificity: 1, vary: { language: 'en' } }, { body: [Buffer.from('a')] })
+  equal(cache.count, 2)
+  equal(cache.size, 3)
+
+  cache.deleteEntry('p:', { ...base, id: 'missing' })
+  cache.deleteEntry('p:', { ...base, id: 'a' })
+  equal(cache.count, 1)
+
+  cache.delete('p:', base)
+  equal(cache.count, 0)
+
+  cache.set('p:', { ...base, id: 'c', specificity: 0, vary: {} }, { body: [Buffer.from('ccc')] })
+  cache.set('p:', { ...base, path: '/bar', id: 'd', specificity: 0, vary: {} }, { body: [Buffer.from('ddd')] })
+  equal(cache.count, 1)
+})
+
+test('v2 utility helpers cover normalization and matching branches', () => {
+  deepStrictEqual(serializeHeaders(undefined), {})
+  deepStrictEqual(serializeHeaders({ B: '', C: undefined, A: ['one', 'two'] }), { a: 'one, two' })
+  equal(serializeForHash(['a', 'b']), '["a","b"]')
+  equal(encodeBodyChunk('hello'), Buffer.from('hello').toString('base64'))
+  equal(encodeBodyChunk(Buffer.from('hello')), Buffer.from('hello').toString('base64'))
+  deepStrictEqual(decodeBody(''), [])
+  deepStrictEqual(decodeBody(`${Buffer.from('a').toString('base64')} ${Buffer.from('b').toString('base64')}`), [
+    Buffer.from('a'),
+    Buffer.from('b')
+  ])
+  equal(varyMatches({ vary: undefined }, {}), true)
+  equal(varyMatches({ vary: { language: null } }, {}), true)
+  equal(varyMatches({ vary: { language: 'en' } }, { language: 'en' }), true)
+  equal(varyMatches({ vary: { language: 'en' } }, { language: 'it' }), false)
+  equal(normalizePrefix(undefined), '')
+  equal(normalizePrefix('foo:'), 'foo:')
+  equal(normalizePrefix('foo'), 'foo:')
+  deepStrictEqual(normalizePrefixes('foo:', undefined), ['foo:'])
+  deepStrictEqual(normalizePrefixes('foo:', 'bar'), ['bar:'])
+  deepStrictEqual(normalizePrefixes('foo:', ['bar', 'baz:']), ['bar:', 'baz:'])
+  equal(validateHashTagPart('prefix', '', true), '')
+  equal(validateHashTagPart('clusterId', 'tenant', false), 'tenant')
+  throws(() => validateHashTagPart('prefix', 1, true), /prefix must be a string/)
+  throws(() => validateHashTagPart('prefix', 'a{b', true), /prefix cannot contain/)
+  throws(() => validateHashTagPart('clusterId', '', false), /clusterId must be a non-empty string/)
+  throws(() => validateHashTagPart('clusterId', undefined, false), /clusterId must be a non-empty string/)
+  deepStrictEqual(unique(['a', 'a', 'b']), ['a', 'b'])
+})
+
+test('v2 cluster hash tag key shapes are stable', async () => {
+  await cleanValkey()
+
+  async function writeAndGetKeys (opts) {
+    await cleanValkey()
+    const store = new RedisCache({ ...opts, tracking: false })
+    try {
+      await write(store, { origin: 'https://example.com', method: 'GET', path: '/foo' }, cacheValue(), 'foo')
+      return await getAllKeys()
+    } finally {
+      await store.close()
+    }
+  }
+
+  {
+    const keys = await writeAndGetKeys({ prefix: '' })
+    ok(keys.length > 0)
+    ok(keys.every(key => key.startsWith('{data:v2}:')))
+  }
+
+  {
+    const keys = await writeAndGetKeys({ prefix: 'app' })
+    ok(keys.length > 0)
+    ok(keys.every(key => key.startsWith('{app:data:v2}:')))
+  }
+
+  {
+    const keys = await writeAndGetKeys({ prefix: '', clusterId: 'tenant-a' })
+    ok(keys.length > 0)
+    ok(keys.every(key => key.startsWith('{tenant-a}:data:v2:')))
+  }
+
+  {
+    const keys = await writeAndGetKeys({ prefix: 'app', clusterId: 'tenant-a' })
+    ok(keys.length > 0)
+    ok(keys.every(key => key.startsWith('app:{tenant-a}:data:v2:')))
+  }
+
+  throws(() => new RedisCache({ prefix: 'bad{prefix}' }), /prefix cannot contain/)
+  throws(() => new RedisCache({ clusterId: '' }), /clusterId must be a non-empty string/)
+  throws(() => new RedisCache({ clusterId: 'bad}' }), /clusterId cannot contain/)
+  throws(() => new RedisCache({ prefix: 1 }), /prefix must be a string/)
+  throws(() => new RedisCache({ clusterId: 1 }), /clusterId must be a string/)
+})
+
+test('v2 exposes manager operations and multi-prefix reads', async (t) => {
+  await cleanValkey()
+
+  const prefix1 = `${crypto.randomUUID()}:`
+  const prefix2 = `${crypto.randomUUID()}:`
+  const store1 = new RedisCache({ prefix: prefix1, tracking: true, clientConfigTracking: false, cacheTagsHeader: 'cache-tag' })
+  const store2 = new RedisCache({ prefix: prefix2, tracking: false, cacheTagsHeader: 'cache-tag' })
+  t.after(async () => {
+    await store1.close()
+    await store1.close()
+    await store2.close()
+  })
+
+  equal(store1.version, '2.0.0')
+  equal(store1.dataVersion, 'v2')
+  equal(store1.prefix, prefix1)
+  ok(store1.client)
+
+  throws(() => new RedisCache(null), TypeError)
+
+  const key1 = { origin: 'https://example.com', method: 'GET', path: '/foo', headers: { language: 'en' } }
+  const key2 = { origin: 'https://example.com', method: 'POST', path: '/foo' }
+  const key3 = { origin: 'https://example.com', method: 'GET', path: '/bar' }
+
+  await write(store1, key1, cacheValue({ headers: { 'cache-tag': ['tag1', 'tag2'], etag: 'abc' }, vary: { language: 'en' } }), 'foo')
+  await write(store1, key2, cacheValue({ headers: { 'cache-tag': 'tag1,tag2,tag3' } }), 'post')
+  await write(store2, key3, cacheValue({ headers: { 'cache-tag': 'tag2' } }), 'bar')
+
+  const first = await store1.get(key1)
+  equal(first.etag, 'abc')
+
+  const tracked = await store1.get(key1, undefined, false)
+  equal(tracked.body, undefined)
+  equal(tracked.statusCode, 200)
+
+  const multiPrefix = await store1.get(key3, [prefix1, prefix2])
+  deepStrictEqual(multiPrefix.body, [Buffer.from('bar')])
+
+  equal((await store1.getKeys([key1, { ...key1, path: '/missing' }])).length, 1)
+  equal((await store1.entries()).length, 2)
+  equal((await store1.entries({ id: (await store1.entries())[0].id })).length, 1)
+  equal((await store1.entries({ origin: key1.origin, method: 'GET' })).length, 1)
+  equal((await store1.entries({ origin: key1.origin, path: '/foo' })).length, 2)
+  equal((await store1.getTag('tag1')).length, 2)
+  equal((await store1.getTags(['tag1', 'tag2', 'tag1'])).length, 4)
+
+  const streamed = []
+  await store1.streamEntries(entry => streamed.push(entry))
+  equal(streamed.length, 2)
+
+  const entry = streamed.find(entry => entry.method === 'GET')
+  equal(await store1.getResponseById(entry.id), 'foo')
+  equal(await store1.getResponseById('missing'), null)
+
+  const dependent = await store1.getDependentEntries(entry.id)
+  equal(dependent.length, 1)
+  equal((await store1.getDependentEntries('missing')).length, 0)
+
+  await store1.deleteKeys([{ id: entry.id }])
+  equal((await store1.entries()).length, 1)
+
+  const remaining = (await store1.entries())[0]
+  equal((await store1.deleteEntries({ id: remaining.id })).length, 1)
+  equal((await store1.entries()).length, 0)
+
+  await write(store1, key1, cacheValue({ headers: { 'cache-tag': 'tag1' } }), 'foo')
+  await write(store1, key2, cacheValue({ headers: { 'cache-tag': 'tag2' } }), 'post')
+  equal((await store1.deleteEntries({ origin: key1.origin })).length, 2)
+  equal((await store1.entries()).length, 0)
+
+  await store1.deleteTag([])
+  await store1.deleteIds(['missing'])
+  await store1.deleteKeys([{ id: 'missing' }])
+  await store1.deleteKeys([{ origin: key1.origin, method: 'GET', path: '/missing' }])
+})
+
+test('v2 handles max entry size and closed stores', async (t) => {
+  await cleanValkey()
+
+  const store = new RedisCache({ prefix: `${crypto.randomUUID()}:`, tracking: false, maxEntrySize: 2 })
+  t.after(() => store.close())
+
+  await write(store, { origin: 'https://example.com', method: 'GET', path: '/too-big' }, cacheValue(), 'too big')
+  equal((await store.entries()).length, 0)
+
+  await store.close()
+  equal(await store.get({ origin: 'https://example.com', method: 'GET', path: '/too-big' }), undefined)
+  await store.delete({ origin: 'https://example.com', path: '/too-big' })
+  await store.deleteKeys([{ origin: 'https://example.com', method: 'GET', path: '/too-big' }])
+  await store.deleteIds(['missing'])
+})
+
+test('v2 covers error and cleanup branches', async (t) => {
+  await cleanValkey()
+
+  throws(() => new RedisCache('invalid'), /expected opts/)
+
+  const prefix = `${crypto.randomUUID()}:`
+  const store = new RedisCache({ prefix, tracking: false, cacheTagsHeader: 'cache-tag' })
+  t.after(() => store.close())
+
+  const arrayHeaderKey = {
+    origin: 'https://example.com',
+    method: 'GET',
+    path: '/array',
+    headers: { language: ['en', 'us'] }
+  }
+  await write(store, arrayHeaderKey, cacheValue({ vary: { language: ['en', 'us'] } }), 'array')
+  notEqual(await store.get(arrayHeaderKey), undefined)
+
+  await write(store, { origin: 'https://example.com', method: 'GET', path: '/no-tags' }, cacheValue({ headers: { other: 'tag1' } }), 'no-tags')
+  const noTags = await store.entries({ origin: 'https://example.com', method: 'GET', path: '/no-tags' })
+  deepStrictEqual(noTags[0].tags, [])
+
+  const entry = (await store.entries({ origin: 'https://example.com', method: 'GET', path: '/array' }))[0]
+  const bodyKey = (await getAllKeys()).find(key => key.endsWith(`:body:${entry.id}`))
+  await store.client.del(bodyKey)
+  equal(await store.get(arrayHeaderKey), undefined)
+})
+
+test('v2 handles subscription errors', async (t) => {
+  await cleanValkey()
+
+  const prefix = `${crypto.randomUUID()}:`
+  const errors = []
+  const store = new RedisCache({ prefix, tracking: false, errorCallback: err => errors.push(err) })
+  t.after(() => store.close())
+
+  await store.subscribe()
+
+  const malformedKey = `{${prefix}data:v2}:entry:malformed`
+  await store.client.set(malformedKey, '{')
+  await new Promise(resolve => setTimeout(resolve, 100))
+  ok(errors.length > 0)
+
+  await write(store, { origin: 'https://example.com', method: 'GET', path: '/foo' }, cacheValue(), 'foo')
+  const first = await store.get({ origin: 'https://example.com', method: 'GET', path: '/foo' })
+  const second = await store.get({ origin: 'https://example.com', method: 'GET', path: '/foo' })
+  deepStrictEqual(first.body, second.body)
+
+  const entries = await store.entries()
+  await store.deleteIds(entries.map(entry => entry.id))
+})
+
+test('v2 tracking can be enabled without keyspace subscription', async (t) => {
+  await cleanValkey()
+
+  const store = new RedisCache({ prefix: `${crypto.randomUUID()}:`, clientConfigTracking: false })
+  t.after(() => store.close())
+
+  await write(store, { origin: 'https://example.com', method: 'GET', path: '/foo' }, cacheValue(), 'foo')
+  const first = await store.get({ origin: 'https://example.com', method: 'GET', path: '/foo' })
+  const second = await store.get({ origin: 'https://example.com', method: 'GET', path: '/foo' })
+  deepStrictEqual(first.body, second.body)
+})
+
+test('v2 default tracking subscribes to redis invalidations', async (t) => {
+  await cleanValkey()
+
+  const prefix = `${crypto.randomUUID()}:`
+  const store = new RedisCache({ prefix })
+  t.after(() => store.close())
+
+  await new Promise(resolve => setTimeout(resolve, 100))
+
+  await write(store, { origin: 'https://example.com', method: 'GET', path: '/foo' }, cacheValue(), 'foo')
+  const first = await store.get({ origin: 'https://example.com', method: 'GET', path: '/foo' })
+  deepStrictEqual(first.body, [Buffer.from('foo')])
+
+  await store.client.publish('__redis__:invalidate', 'ignored-key')
+  await store.client.publish('__redis__:invalidate', `${prefix}data:v2:resource:test`)
+  await new Promise(resolve => setTimeout(resolve, 100))
+
+  const second = await store.get({ origin: 'https://example.com', method: 'GET', path: '/foo' })
+  deepStrictEqual(second.body, [Buffer.from('foo')])
+})
+
+test('v2 map limit waits when concurrency is reached', async (t) => {
+  await cleanValkey()
+
+  const store = new RedisCache({ prefix: `${crypto.randomUUID()}:`, tracking: false, concurrency: 1 })
+  t.after(() => store.close())
+
+  const key1 = { origin: 'https://example.com', method: 'GET', path: '/one' }
+  const key2 = { origin: 'https://example.com', method: 'GET', path: '/two' }
+
+  await write(store, key1, cacheValue(), 'one')
+  await write(store, key2, cacheValue(), 'two')
+
+  const results = await store.getKeys([key1, key2])
+  equal(results.length, 2)
+})
+
+test('v2 subscription emits entry add and delete events', async (t) => {
+  await cleanValkey()
+
+  const store = new RedisCache({ prefix: `${crypto.randomUUID()}:`, tracking: false, clientConfigKeyspaceEventNotify: true })
+  t.after(() => store.close())
+
+  await store.subscribe()
+  await store.subscribe()
+
+  const add = once(store, 'subscription:entry:add')
+  await write(store, { origin: 'https://example.com', method: 'GET', path: '/foo' }, cacheValue(), 'foo')
+  const [added] = await add
+  equal(added.value.statusCode, 200)
+
+  const del = once(store, 'subscription:entry:delete')
+  await store.deleteIds([added.id])
+  const [deleted] = await del
+  equal(deleted.id, added.id)
+})

--- a/test/v2/compatibility/cache-manager.test.js
+++ b/test/v2/compatibility/cache-manager.test.js
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { test } from 'node:test'
+import { RedisCache } from '../../../index.js'
+import { cleanValkey } from '../../helper.js'
+import { createCachedServer } from './helper.js'
+
+test('v2 cache manager subscribes when notify-keyspace-events is configured on the server', async t => {
+  await cleanValkey()
+  const manager = new RedisCache({ clientConfigKeyspaceEventNotify: false, clientOpts: { url: 'http://localhost:6389' } })
+  t.after(() => manager.close())
+
+  await manager.subscribe()
+})
+
+test('v2 cache manager fails when notify-keyspace-events is not configured on the server', async t => {
+  const manager = new RedisCache({ clientConfigKeyspaceEventNotify: true, clientOpts: { host: 'localhost', port: 6399 } })
+  t.after(() => manager.close())
+
+  await assert.rejects(manager.subscribe())
+})
+
+test('v2 cache manager invalidates response by id', async t => {
+  await cleanValkey()
+  const prefix = `${crypto.randomUUID()}:`
+  const fixture = await createCachedServer(t, { prefix })
+
+  await fixture.client.request({ origin: fixture.origin, method: 'GET', path: '/' }).then(({ body }) => body.text())
+  await sleep(1000)
+  await fixture.client.request({ origin: fixture.origin, method: 'GET', path: '/' }).then(({ body }) => body.text())
+  assert.equal(fixture.requests, 1)
+
+  const entries = await fixture.store.entries({}, prefix)
+  assert.equal(entries.length, 1)
+  await fixture.store.deleteIds([entries[0].id], prefix)
+
+  await fixture.client.request({ origin: fixture.origin, method: 'GET', path: '/' }).then(({ body }) => body.text())
+  assert.equal(fixture.requests, 2)
+})

--- a/test/v2/compatibility/example-server.test.js
+++ b/test/v2/compatibility/example-server.test.js
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { RedisCache } from '../../../index.js'
+
+test('v2 example compatibility exposes default RedisCache constructor', async t => {
+  const cache = new RedisCache({ tracking: false })
+  t.after(() => cache.close())
+
+  assert.equal(typeof cache.get, 'function')
+  assert.equal(typeof cache.entries, 'function')
+})

--- a/test/v2/compatibility/get-dependent-entries.test.js
+++ b/test/v2/compatibility/get-dependent-entries.test.js
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { RedisCache } from '../../../index.js'
+import { cleanValkey } from '../../helper.js'
+import { cacheValue, writeEntry } from './helper.js'
+
+test('v2 getDependentEntries returns entries sharing cache tags', async t => {
+  await cleanValkey()
+  const prefix = `${crypto.randomUUID()}:`
+  const cache = new RedisCache({ prefix, tracking: false, cacheTagsHeader: 'cache-tags' })
+  t.after(() => cache.close())
+
+  await writeEntry(cache, { origin: 'http://example.com', method: 'GET', path: '/foo' }, cacheValue({ headers: { 'cache-tags': 'tag1,tag2' } }), 'foo')
+  await writeEntry(cache, { origin: 'http://example.com', method: 'GET', path: '/bar' }, cacheValue({ headers: { 'cache-tags': 'tag1,tag2,tag3' } }), 'bar')
+
+  const entries = await cache.entries({}, prefix)
+  const source = entries.find(entry => entry.path === '/foo')
+  assert.ok(source)
+  const dependent = await cache.getDependentEntries(source.id, prefix)
+
+  assert.equal(dependent.length, 1)
+  assert.deepEqual(dependent.map(entry => entry.path), ['/bar'])
+})

--- a/test/v2/compatibility/global-invalidation.test.js
+++ b/test/v2/compatibility/global-invalidation.test.js
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { RedisCache } from '../../../index.js'
+import { cleanValkey } from '../../helper.js'
+import { cacheValue, writeEntry } from './helper.js'
+
+test('v2 invalidates same-tag responses across cache instances', async t => {
+  await cleanValkey()
+  const prefix = `${crypto.randomUUID()}:`
+  const cacheA = new RedisCache({ prefix, tracking: false, cacheTagsHeader: 'cache-tags' })
+  const cacheB = new RedisCache({ prefix, tracking: false, cacheTagsHeader: 'cache-tags' })
+  t.after(async () => {
+    await cacheA.close()
+    await cacheB.close()
+  })
+
+  const key = { origin: 'http://example.com', method: 'GET', path: '/foo' }
+  await writeEntry(cacheA, key, cacheValue({ headers: { 'cache-tags': 'shared' } }), 'foo')
+  assert.notEqual(await cacheB.get(key), undefined)
+
+  await cacheB.deleteTags(['shared'], prefix)
+  assert.equal(await cacheA.get(key), undefined)
+})

--- a/test/v2/compatibility/helper.js
+++ b/test/v2/compatibility/helper.js
@@ -1,0 +1,67 @@
+import { once } from 'node:events'
+import { createServer } from 'node:http'
+import { Client, interceptors } from 'undici'
+import { RedisCache } from '../../../index.js'
+
+export function cacheValue (opts = {}) {
+  return {
+    statusCode: 200,
+    statusMessage: '',
+    headers: opts.headers ?? {},
+    vary: opts.vary,
+    cachedAt: opts.cachedAt ?? Date.now(),
+    staleAt: opts.staleAt ?? Date.now() + 10000,
+    deleteAt: opts.deleteAt ?? Date.now() + 20000,
+    cacheControlDirectives: opts.cacheControlDirectives ?? {}
+  }
+}
+
+export async function writeEntry (cache, key, value, body) {
+  const stream = cache.createWriteStream(key, value)
+  if (Array.isArray(body)) {
+    for (const chunk of body) {
+      stream.write(chunk)
+    }
+    stream.end()
+  } else {
+    stream.end(body)
+  }
+  await once(stream, 'close')
+}
+
+export async function createCachedServer (t, opts = {}) {
+  let requests = 0
+  const server = createServer((req, res) => {
+    requests++
+    res.setHeader('cache-control', opts.cacheControl ?? 'public, s-maxage=100')
+    if (opts.cacheTagsHeader && opts.cacheTags) {
+      res.setHeader(opts.cacheTagsHeader, opts.cacheTags)
+    }
+    res.end(opts.body ?? 'asd')
+  }).listen(0)
+
+  await once(server, 'listening')
+
+  const origin = `http://localhost:${server.address().port}`
+  const store = new RedisCache({
+    prefix: opts.prefix ?? `${crypto.randomUUID()}:`,
+    tracking: opts.tracking ?? false,
+    cacheTagsHeader: opts.cacheTagsHeader
+  })
+  const client = new Client(origin).compose(interceptors.cache({ store }))
+
+  t.after(async () => {
+    server.close()
+    await client.close()
+    await store.close()
+  })
+
+  return {
+    client,
+    origin,
+    store,
+    get requests () {
+      return requests
+    }
+  }
+}

--- a/test/v2/compatibility/interceptor.test.js
+++ b/test/v2/compatibility/interceptor.test.js
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { test } from 'node:test'
+import { cleanValkey } from '../../helper.js'
+import { createCachedServer } from './helper.js'
+
+test('v2 caches request successfully through undici interceptor', async t => {
+  await cleanValkey()
+  const fixture = await createCachedServer(t)
+
+  await fixture.client.request({ origin: fixture.origin, method: 'GET', path: '/' }).then(({ body }) => body.text())
+  await sleep(1000)
+  const second = await fixture.client.request({ origin: fixture.origin, method: 'GET', path: '/' })
+
+  assert.equal(await second.body.text(), 'asd')
+  assert.equal(fixture.requests, 1)
+  assert.ok(second.headers.age)
+})
+
+test('v2 invalidates response by cache tag through undici interceptor', async t => {
+  await cleanValkey()
+  const fixture = await createCachedServer(t, { cacheTagsHeader: 'cache-tag', cacheTags: 'tag1' })
+
+  await fixture.client.request({ origin: fixture.origin, method: 'GET', path: '/' }).then(({ body }) => body.text())
+  await sleep(1000)
+  await fixture.store.deleteTags(['tag1'])
+  await fixture.client.request({ origin: fixture.origin, method: 'GET', path: '/' }).then(({ body }) => body.text())
+
+  assert.equal(fixture.requests, 2)
+})
+
+test('v2 invalidates GET cache by making POST to the same url', async t => {
+  await cleanValkey()
+  const fixture = await createCachedServer(t)
+
+  await fixture.client.request({ origin: fixture.origin, method: 'GET', path: '/' }).then(({ body }) => body.text())
+  await fixture.client.request({ origin: fixture.origin, method: 'POST', path: '/', body: 'mutate' }).then(({ body }) => body.text())
+  await fixture.client.request({ origin: fixture.origin, method: 'GET', path: '/' }).then(({ body }) => body.text())
+
+  assert.equal(fixture.requests, 3)
+})

--- a/test/v2/compatibility/proxy-server.test.js
+++ b/test/v2/compatibility/proxy-server.test.js
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict'
+import { Agent, interceptors } from 'undici'
+import { test } from 'node:test'
+import { RedisCache } from '../../../index.js'
+
+test('v2 proxy compatibility creates an undici agent with the default cache store', async t => {
+  const store = new RedisCache({ tracking: false })
+  const agent = new Agent().compose(interceptors.cache({ store }))
+  t.after(async () => {
+    await agent.close()
+    await store.close()
+  })
+
+  assert.ok(agent)
+})

--- a/test/v2/compatibility/redis-cache-store.test.js
+++ b/test/v2/compatibility/redis-cache-store.test.js
@@ -1,0 +1,71 @@
+import { deepStrictEqual, equal, notEqual } from 'node:assert'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { describe, test } from 'node:test'
+import { RedisCache } from '../../../index.js'
+import { cleanValkey } from '../../helper.js'
+import { cacheValue, writeEntry } from './helper.js'
+
+describe('RedisCache V2 store compatibility', () => {
+  test('matches store interface', async t => {
+    const store = new RedisCache({ tracking: false })
+    t.after(() => store.close())
+
+    equal(typeof store.get, 'function')
+    equal(typeof store.createWriteStream, 'function')
+    equal(typeof store.delete, 'function')
+    equal(typeof store.deleteKeys, 'function')
+  })
+
+  test('basic functionality', async t => {
+    await cleanValkey()
+    const store = new RedisCache({ prefix: `${crypto.randomUUID()}:`, tracking: false })
+    t.after(() => store.close())
+
+    const key = { origin: 'localhost', path: '/', method: 'GET', headers: {} }
+    const value = cacheValue({ headers: { foo: 'bar' } })
+    await writeEntry(store, key, value, ['asd', '123'])
+
+    const result = await store.get({ ...key })
+    notEqual(result, undefined)
+    deepStrictEqual(result.body, [Buffer.from('asd'), Buffer.from('123')])
+    equal(result.headers.foo, 'bar')
+  })
+
+  test('returns stale response if possible', async t => {
+    await cleanValkey()
+    const store = new RedisCache({ prefix: `${crypto.randomUUID()}:`, tracking: false })
+    t.after(() => store.close())
+
+    const key = { origin: 'localhost', path: '/', method: 'GET', headers: {} }
+    const value = cacheValue({ cachedAt: Date.now() - 10000, staleAt: Date.now() - 1 })
+    await writeEntry(store, key, value, 'stale')
+
+    const result = await store.get(key)
+    notEqual(result, undefined)
+    deepStrictEqual(result.body, [Buffer.from('stale')])
+  })
+
+  test('does not return response past deletedAt', async t => {
+    await cleanValkey()
+    const store = new RedisCache({ prefix: `${crypto.randomUUID()}:`, tracking: false })
+    t.after(() => store.close())
+
+    const key = { origin: 'localhost', path: '/', method: 'GET', headers: {} }
+    await writeEntry(store, key, cacheValue({ deleteAt: Date.now() + 1000 }), 'expired')
+    await sleep(1200)
+
+    equal(await store.get(key), undefined)
+  })
+
+  test('respects vary directives', async t => {
+    await cleanValkey()
+    const store = new RedisCache({ prefix: `${crypto.randomUUID()}:`, tracking: false })
+    t.after(() => store.close())
+
+    const key = { origin: 'localhost', path: '/', method: 'GET', headers: { language: 'en' } }
+    await writeEntry(store, key, cacheValue({ vary: { language: 'en' } }), 'en')
+
+    notEqual(await store.get({ ...key }), undefined)
+    equal(await store.get({ ...key, headers: { language: 'it' } }), undefined)
+  })
+})

--- a/test/v2/compatibility/scanByPattern.test.js
+++ b/test/v2/compatibility/scanByPattern.test.js
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { RedisCache } from '../../../index.js'
+import { cleanValkey, getAllKeys } from '../../helper.js'
+import { cacheValue, writeEntry } from './helper.js'
+
+test('v2 compatibility lookup uses indexed data instead of scan-backed metadata keys', async t => {
+  await cleanValkey()
+  const cache = new RedisCache({ prefix: `${crypto.randomUUID()}:`, tracking: false })
+  t.after(() => cache.close())
+
+  await writeEntry(cache, { origin: 'http://example.com', method: 'GET', path: '/' }, cacheValue(), 'asd')
+
+  const result = await cache.get({ origin: 'http://example.com', method: 'GET', path: '/' })
+  assert.notEqual(result, undefined)
+
+  const keys = await getAllKeys()
+  assert.equal(keys.some(key => key.includes('metadata:')), false)
+})

--- a/test/v2/compatibility/stale.test.js
+++ b/test/v2/compatibility/stale.test.js
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { test } from 'node:test'
+import { cleanValkey } from '../../helper.js'
+import { createCachedServer } from './helper.js'
+
+test('v2 serves stale response while revalidating', async t => {
+  await cleanValkey()
+  const fixture = await createCachedServer(t, { cacheControl: 'public, s-maxage=1, stale-while-revalidate=5' })
+
+  await fixture.client.request({ origin: fixture.origin, method: 'GET', path: '/' }).then(({ body }) => body.text())
+  await sleep(1200)
+  const stale = await fixture.client.request({ origin: fixture.origin, method: 'GET', path: '/' })
+
+  assert.equal(await stale.body.text(), 'asd')
+  assert.equal(fixture.requests, 1)
+})

--- a/test/v2/compatibility/stream-entries.test.js
+++ b/test/v2/compatibility/stream-entries.test.js
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { test } from 'node:test'
+import { cleanValkey } from '../../helper.js'
+import { createCachedServer } from './helper.js'
+
+test('v2 streamEntries streams cache entries for a prefix', async t => {
+  await cleanValkey()
+  const prefix = `${crypto.randomUUID()}:`
+  const fixture = await createCachedServer(t, { prefix, cacheTagsHeader: 'x-cache-tags', cacheTags: 'tag1,tag2' })
+
+  await fixture.client.request({ origin: fixture.origin, method: 'GET', path: '/' }).then(({ body }) => body.text())
+  await sleep(1000)
+
+  const entries = []
+  await fixture.store.streamEntries(entry => entries.push(entry), prefix)
+
+  assert.equal(entries.length, 1)
+  assert.equal(entries[0].prefix, prefix)
+  assert.deepEqual(entries[0].cacheTags, ['tag1', 'tag2'])
+})

--- a/test/v2/compatibility/subscribe.test.js
+++ b/test/v2/compatibility/subscribe.test.js
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict'
+import { once } from 'node:events'
+import { test } from 'node:test'
+import { RedisCache } from '../../../index.js'
+import { cleanValkey } from '../../helper.js'
+import { cacheValue, writeEntry } from './helper.js'
+
+test('v2 subscription notifies when a new key is added', async t => {
+  await cleanValkey()
+  const prefix = `${crypto.randomUUID()}:`
+  const cache = new RedisCache({ prefix, tracking: false, cacheTagsHeader: 'cache-tags' })
+  t.after(() => cache.close())
+
+  await cache.subscribe(prefix)
+  const event = once(cache, 'subscription:entry:add')
+  await writeEntry(cache, { origin: 'http://example.com', method: 'GET', path: '/' }, cacheValue({ headers: { 'cache-tags': 'tag1,tag2' } }), 'asd')
+
+  const [entry] = await event
+  assert.ok(entry.id)
+  assert.equal(entry.prefix, prefix)
+  assert.deepEqual(entry.metadata.tags, ['tag1', 'tag2'])
+})
+
+test('v2 subscription notifies when an entry is deleted', async t => {
+  await cleanValkey()
+  const prefix = `${crypto.randomUUID()}:`
+  const cache = new RedisCache({ prefix, tracking: false })
+  t.after(() => cache.close())
+
+  const key = { origin: 'http://example.com', method: 'GET', path: '/' }
+  await writeEntry(cache, key, cacheValue(), 'asd')
+  const entries = await cache.entries({}, prefix)
+
+  await cache.subscribe(prefix)
+  const event = once(cache, 'subscription:entry:delete')
+  await cache.deleteIds([entries[0].id], prefix)
+
+  const [entry] = await event
+  assert.equal(entry.id, entries[0].id)
+  assert.equal(entry.prefix, prefix)
+})

--- a/test/v2/compatibility/tracking-cache.test.js
+++ b/test/v2/compatibility/tracking-cache.test.js
@@ -1,0 +1,40 @@
+import { deepStrictEqual, strictEqual } from 'node:assert'
+import { test } from 'node:test'
+import TrackingCache from '../../../src/v2/tracking-cache.js'
+
+test('v2 tracking cache overrides cache entries', () => {
+  const cache = new TrackingCache()
+  const metadata = { id: '1', origin: 'http://test.com', method: 'GET', path: '/foo' }
+
+  cache.set('', metadata, { body: ['one'] })
+  cache.set('', { ...metadata, id: '2' }, { body: ['two'] })
+
+  strictEqual(cache.count, 2)
+  deepStrictEqual(cache.get('', metadata), { body: ['one'] })
+})
+
+test('v2 tracking cache deletes values when reaching a count threshold', () => {
+  const cache = new TrackingCache({ maxCount: 2 })
+  cache.set('', { id: '1', origin: 'http://a.com', method: 'GET', path: '/' }, { body: ['a'] })
+  cache.set('', { id: '2', origin: 'http://b.com', method: 'GET', path: '/' }, { body: ['b'] })
+  cache.set('', { id: '3', origin: 'http://c.com', method: 'GET', path: '/' }, { body: ['c'] })
+
+  strictEqual(cache.count, 2)
+})
+
+test('v2 tracking cache respects vary directives', () => {
+  const cache = new TrackingCache()
+  const metadata = {
+    id: '1',
+    origin: 'http://test.com',
+    method: 'GET',
+    path: '/foo',
+    vary: { 'accept-encoding': 'gzip' },
+    specificity: 1
+  }
+
+  cache.set('', metadata, { body: ['gzip'] })
+
+  deepStrictEqual(cache.get('', { ...metadata, headers: { 'accept-encoding': 'gzip' } }), { body: ['gzip'] })
+  strictEqual(cache.get('', { ...metadata, headers: { 'accept-encoding': 'deflate' } }), undefined)
+})


### PR DESCRIPTION
# PR Review Guide

Review this as a next-major change. The main intent is to make the new `RedisCache` API the default, keep V1 available explicitly, move the project to ESM-only, and replace the V1 scan-heavy Redis model with an indexed V2 model.

## Main Areas To Review

### Public API

Check that the default API is now `RedisCache`.

Expected exports:

- default export: `RedisCache`
- named exports: `RedisCache`, `RedisCacheStore`, `RedisCacheManager`, `createStore`, `createManager`
- `createStore(opts)` and `createManager(opts)` return `RedisCache`
- `createStore(opts, '1')` / `createStore(opts, '1.0.0')` return V1 `RedisCacheStore`
- `createManager(opts, '1')` / `createManager(opts, '1.0.0')` return V1 `RedisCacheManager`

Check that this is reflected consistently in:

- `index.js`
- `index.d.ts`
- `src/v1/index.d.ts`
- `src/v2/index.d.ts`

### ESM-Only Package

The package is now ESM-only.

Review:

- `package.json` has `"type": "module"`
- `exports` only exposes an `import` condition
- no `require`, `module.exports`, `exports.*`, or `'use strict'` remains
- examples, tests, benchmarks, and config are ESM
- `lib/` is removed and no docs/tests/source still point to it

### V1 Preservation

V1 implementation moved under `src/v1`.

Review that V1 behavior was preserved, not rewritten:

- `RedisCacheStore`
- `RedisCacheManager`
- `TrackingCache`
- V1 tests moved to `test/v1`
- V1 docs live in `docs/v1.md`

V1 compatibility is intentionally explicit through named exports and versioned factories.

### V2 Data Model

V2 lives under `src/v2`.

Review the indexed Redis model:

- metadata: `entry:{id}`
- body: `body:{id}`
- indexes: sorted sets scored by `deleteAt`
- resource index: origin + method + path
- tag indexes: hashed tag keys
- original tags stored in entry metadata
- payload keys expire with `SET ... EXAT`
- index keys expire with `EXPIREAT ... NX` and `EXPIREAT ... GT`

Important files:

- `src/v2/cache.js`
- `src/v2/keys.js`
- `src/v2/utils.js`

### Prefix And Cluster Key Shape

Review prefix normalization and Redis Cluster hash tags.

Expected behavior:

- `prefix: 'app'` becomes `app:`
- empty prefix stays empty
- without `clusterId`: hash tag includes namespace and data version, e.g. `{app:data:v2}:entry:{id}`
- with `clusterId`: only the cluster id is hash-tagged, e.g. `app:{tenant-a}:data:v2:entry:{id}`
- `prefix` and `clusterId` reject `{` and `}`
- `clusterId` cannot be empty when provided

Relevant files:

- `src/v2/utils.js`
- `src/v2/keys.js`
- `test/v2/cache.test.js`

### Vary Handling

V2 lookup must select the most specific matching variant.

Expected behavior:

- entries are indexed by origin + method + path
- all live variants for that resource are loaded
- request headers are normalized
- matching variants are filtered with `varyMatches`
- the matching entry with the highest `specificity` wins

Review:

- `src/v2/cache.js`
- `src/v2/tracking-cache.js`
- `test/v2/cache.test.js`, especially the most-specific vary test

### Tag Handling

Review that tag handling matches the intended model.

Expected behavior:

- tags are read from `cacheTagsHeader`
- original tag strings are stored in metadata as `entry.tags`
- hashed tags are stored as `entry.tagHashes`
- Redis tag index keys use hashes only
- `deleteTag`, `deleteTags`, `getTag`, `getTags`, and `getDependentEntries` operate through the tag indexes

Relevant areas:

- write path in `src/v2/cache.js`
- `#getTagHashes`
- `#getEntryIndexKeys`
- tag tests in `test/v2/cache.test.js` and `test/v2/compatibility`

### Manager Semantics

`RedisCache` now also acts as the manager API.

Review:

- `entries`
- `deleteEntries`
- `streamEntries`
- `getTag`
- `getTags`
- `getResponseById`
- `getDependentEntries`
- `deleteIds`
- `subscribe`

Check that V1 manager semantics are covered by V2 compatibility tests under:

- `test/v2/compatibility`

### Subscription Behavior

V2 uses separate Redis clients for:

- main commands
- client-side tracking invalidations
- keyspace subscriptions

Review:

- `#subscribeTracking`
- `subscribe`
- subscription event payloads
- cleanup in `close`

Expected events:

- `entry:write`
- `entry:delete`
- `tag:delete`
- `subscription:entry:add`
- `subscription:entry:delete`
- `error`

### Tests Organization

Tests are split by API generation:

- V1 tests: `test/v1`
- V2 direct tests: `test/v2/cache.test.js`
- V2 compatibility counterparts: `test/v2/compatibility`

There should be one V2 compatibility counterpart for each V1 test file.

### Docs

Review docs for consistency with the new default API:

- `README.md` should describe the default API without calling it “V2”
- V1 details should be preserved in `docs/v1.md`
- data model docs may mention `data:v2`
- migration docs may mention V2 explicitly

Check especially:

- README examples use ESM imports
- V1 compatibility examples use named imports
- no `require(...)` examples remain

## Review Priorities

Focus on behavioral regressions and public API correctness first.

High-value review questions:

- Does V1 still behave the same through explicit V1 exports?
- Does default import now behave correctly as `RedisCache`?
- Are there any accidental CommonJS entry points left?
- Are Redis keys stable and correctly namespaced?
- Can V1 and V2 data coexist safely?
- Does V2 avoid `SCAN` on the HTTP lookup path?
- Are tag indexes hashed while original tags remain inspectable?
- Does Vary selection pick the most specific matching entry?
- Are subscription and tracking clients independent and cleaned up?
- Are TypeScript declarations aligned with runtime exports?